### PR TITLE
Update the current year in the license text

### DIFF
--- a/admin/admin_board.php
+++ b/admin/admin_board.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/admin/admin_bt_forum_cfg.php
+++ b/admin/admin_bt_forum_cfg.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/admin/admin_bt_tracker_cfg.php
+++ b/admin/admin_bt_tracker_cfg.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/admin/admin_cron.php
+++ b/admin/admin_cron.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/admin/admin_disallow.php
+++ b/admin/admin_disallow.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/admin/admin_forum_prune.php
+++ b/admin/admin_forum_prune.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/admin/admin_forumauth.php
+++ b/admin/admin_forumauth.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/admin/admin_forumauth_list.php
+++ b/admin/admin_forumauth_list.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/admin/admin_forums.php
+++ b/admin/admin_forums.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/admin/admin_groups.php
+++ b/admin/admin_groups.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/admin/admin_log.php
+++ b/admin/admin_log.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/admin/admin_mass_email.php
+++ b/admin/admin_mass_email.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/admin/admin_phpinfo.php
+++ b/admin/admin_phpinfo.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/admin/admin_ranks.php
+++ b/admin/admin_ranks.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/admin/admin_rebuild_search.php
+++ b/admin/admin_rebuild_search.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/admin/admin_sitemap.php
+++ b/admin/admin_sitemap.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/admin/admin_smilies.php
+++ b/admin/admin_smilies.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/admin/admin_terms.php
+++ b/admin/admin_terms.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/admin/admin_ug_auth.php
+++ b/admin/admin_ug_auth.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/admin/admin_user_ban.php
+++ b/admin/admin_user_ban.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/admin/admin_user_search.php
+++ b/admin/admin_user_search.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/admin/admin_words.php
+++ b/admin/admin_words.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/admin/index.php
+++ b/admin/index.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/admin/pagestart.php
+++ b/admin/pagestart.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/admin/stats/tr_stats.php
+++ b/admin/stats/tr_stats.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/admin/stats/tracker.php
+++ b/admin/stats/tracker.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/ajax.php
+++ b/ajax.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app.php
+++ b/app.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/bt/announce.php
+++ b/bt/announce.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/bt/includes/init_tr.php
+++ b/bt/includes/init_tr.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/bt/index.php
+++ b/bt/index.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/bt/scrape.php
+++ b/bt/scrape.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/callseed.php
+++ b/callseed.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/common.php
+++ b/common.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/configs/main.php
+++ b/configs/main.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/cron.php
+++ b/cron.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/dl.php
+++ b/dl.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/dl_list.php
+++ b/dl_list.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feed.php
+++ b/feed.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/group.php
+++ b/group.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/group_edit.php
+++ b/group_edit.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/index.php
+++ b/index.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/info.php
+++ b/info.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/ajax/avatar.php
+++ b/library/ajax/avatar.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/ajax/change_tor_status.php
+++ b/library/ajax/change_tor_status.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/ajax/change_torrent.php
+++ b/library/ajax/change_torrent.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/ajax/change_user_opt.php
+++ b/library/ajax/change_user_opt.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/ajax/change_user_rank.php
+++ b/library/ajax/change_user_rank.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/ajax/edit_group_profile.php
+++ b/library/ajax/edit_group_profile.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/ajax/edit_user_profile.php
+++ b/library/ajax/edit_user_profile.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/ajax/gen_passkey.php
+++ b/library/ajax/gen_passkey.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/ajax/group_membership.php
+++ b/library/ajax/group_membership.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/ajax/index_data.php
+++ b/library/ajax/index_data.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/ajax/manage_admin.php
+++ b/library/ajax/manage_admin.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/ajax/manage_user.php
+++ b/library/ajax/manage_user.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/ajax/mod_action.php
+++ b/library/ajax/mod_action.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/ajax/post_mod_comment.php
+++ b/library/ajax/post_mod_comment.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/ajax/posts.php
+++ b/library/ajax/posts.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/ajax/sitemap.php
+++ b/library/ajax/sitemap.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/ajax/topic_tpl.php
+++ b/library/ajax/topic_tpl.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/ajax/user_register.php
+++ b/library/ajax/user_register.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/ajax/view_post.php
+++ b/library/ajax/view_post.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/ajax/view_torrent.php
+++ b/library/ajax/view_torrent.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/config.php
+++ b/library/config.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/defines.php
+++ b/library/defines.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/bbcode.php
+++ b/library/includes/bbcode.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/classes/emailer.php
+++ b/library/includes/classes/emailer.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/classes/sitemap.php
+++ b/library/includes/classes/sitemap.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/core/dbs.php
+++ b/library/includes/core/dbs.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/core/mysql.php
+++ b/library/includes/core/mysql.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/cron/cron_check.php
+++ b/library/includes/cron/cron_check.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/cron/cron_init.php
+++ b/library/includes/cron/cron_init.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/cron/cron_run.php
+++ b/library/includes/cron/cron_run.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/cron/jobs/board_maintenance.php
+++ b/library/includes/cron/jobs/board_maintenance.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/cron/jobs/clean_dlstat.php
+++ b/library/includes/cron/jobs/clean_dlstat.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/cron/jobs/clean_log.php
+++ b/library/includes/cron/jobs/clean_log.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/cron/jobs/clean_search_results.php
+++ b/library/includes/cron/jobs/clean_search_results.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/cron/jobs/ds_update_cat_forums.php
+++ b/library/includes/cron/jobs/ds_update_cat_forums.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/cron/jobs/ds_update_stats.php
+++ b/library/includes/cron/jobs/ds_update_stats.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/cron/jobs/flash_topic_view.php
+++ b/library/includes/cron/jobs/flash_topic_view.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/cron/jobs/prune_forums.php
+++ b/library/includes/cron/jobs/prune_forums.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/cron/jobs/prune_inactive_users.php
+++ b/library/includes/cron/jobs/prune_inactive_users.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/cron/jobs/prune_topic_moved.php
+++ b/library/includes/cron/jobs/prune_topic_moved.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/cron/jobs/sessions_cleanup.php
+++ b/library/includes/cron/jobs/sessions_cleanup.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/cron/jobs/sitemap.php
+++ b/library/includes/cron/jobs/sitemap.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/cron/jobs/tr_cleanup_and_dlstat.php
+++ b/library/includes/cron/jobs/tr_cleanup_and_dlstat.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/cron/jobs/tr_complete_count.php
+++ b/library/includes/cron/jobs/tr_complete_count.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/cron/jobs/tr_maintenance.php
+++ b/library/includes/cron/jobs/tr_maintenance.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/cron/jobs/tr_make_snapshot.php
+++ b/library/includes/cron/jobs/tr_make_snapshot.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/cron/jobs/tr_seed_bonus.php
+++ b/library/includes/cron/jobs/tr_seed_bonus.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/cron/jobs/tr_update_seeder_last_seen.php
+++ b/library/includes/cron/jobs/tr_update_seeder_last_seen.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/cron/jobs/update_forums_atom.php
+++ b/library/includes/cron/jobs/update_forums_atom.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/datastore/apc.php
+++ b/library/includes/datastore/apc.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/datastore/build_cat_forums.php
+++ b/library/includes/datastore/build_cat_forums.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/datastore/build_moderators.php
+++ b/library/includes/datastore/build_moderators.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/datastore/build_ranks.php
+++ b/library/includes/datastore/build_ranks.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/datastore/build_smilies.php
+++ b/library/includes/datastore/build_smilies.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/datastore/build_stats.php
+++ b/library/includes/datastore/build_stats.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/datastore/common.php
+++ b/library/includes/datastore/common.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/datastore/file.php
+++ b/library/includes/datastore/file.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/datastore/memcache.php
+++ b/library/includes/datastore/memcache.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/datastore/redis.php
+++ b/library/includes/datastore/redis.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/datastore/sqlite.php
+++ b/library/includes/datastore/sqlite.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/datastore/xcache.php
+++ b/library/includes/datastore/xcache.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/functions.php
+++ b/library/includes/functions.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/functions_admin.php
+++ b/library/includes/functions_admin.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/functions_admin_cron.php
+++ b/library/includes/functions_admin_cron.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/functions_admin_torrent.php
+++ b/library/includes/functions_admin_torrent.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/functions_atom.php
+++ b/library/includes/functions_atom.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/functions_dev.php
+++ b/library/includes/functions_dev.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/functions_group.php
+++ b/library/includes/functions_group.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/functions_post.php
+++ b/library/includes/functions_post.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/functions_selects.php
+++ b/library/includes/functions_selects.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/functions_torrent.php
+++ b/library/includes/functions_torrent.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/functions_upload.php
+++ b/library/includes/functions_upload.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/functions_validate.php
+++ b/library/includes/functions_validate.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/init_bb.php
+++ b/library/includes/init_bb.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/online_userlist.php
+++ b/library/includes/online_userlist.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/page_footer.php
+++ b/library/includes/page_footer.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/page_footer_dev.php
+++ b/library/includes/page_footer_dev.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/page_header.php
+++ b/library/includes/page_header.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/posting_tpl.php
+++ b/library/includes/posting_tpl.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/sessions.php
+++ b/library/includes/sessions.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/smtp.php
+++ b/library/includes/smtp.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/template.php
+++ b/library/includes/template.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/torrent_show_dl_list.php
+++ b/library/includes/torrent_show_dl_list.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/ucp/activate.php
+++ b/library/includes/ucp/activate.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/ucp/bonus.php
+++ b/library/includes/ucp/bonus.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/ucp/email.php
+++ b/library/includes/ucp/email.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/ucp/register.php
+++ b/library/includes/ucp/register.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/ucp/sendpasswd.php
+++ b/library/includes/ucp/sendpasswd.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/ucp/topic_watch.php
+++ b/library/includes/ucp/topic_watch.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/ucp/viewprofile.php
+++ b/library/includes/ucp/viewprofile.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/ucp/viewtorrent.php
+++ b/library/includes/ucp/viewtorrent.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/includes/viewtopic_torrent.php
+++ b/library/includes/viewtopic_torrent.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/language/en/main.php
+++ b/library/language/en/main.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/language/ru/main.php
+++ b/library/language/ru/main.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/language/uk/main.php
+++ b/library/language/uk/main.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/login.php
+++ b/login.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/memberlist.php
+++ b/memberlist.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/messages/en.php
+++ b/messages/en.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/messages/ru.php
+++ b/messages/ru.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/modcp.php
+++ b/modcp.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/poll.php
+++ b/poll.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/posting.php
+++ b/posting.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/privmsg.php
+++ b/privmsg.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/profile.php
+++ b/profile.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/search.php
+++ b/search.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/Cache/Adapter.php
+++ b/src/Cache/Adapter.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/Cache/FileAdapter.php
+++ b/src/Cache/FileAdapter.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/Cache/MemoryAdapter.php
+++ b/src/Cache/MemoryAdapter.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/Config.php
+++ b/src/Config.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/Db/Adapter.php
+++ b/src/Db/Adapter.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/Db/Entity.php
+++ b/src/Db/Entity.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/Db/PrepareStatement.php
+++ b/src/Db/PrepareStatement.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/Di.php
+++ b/src/Di.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/Log.php
+++ b/src/Log.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/ServiceProviders/CacheServiceProvider.php
+++ b/src/ServiceProviders/CacheServiceProvider.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/ServiceProviders/CaptchaServiceProvider.php
+++ b/src/ServiceProviders/CaptchaServiceProvider.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/ServiceProviders/ConfigServiceProvider.php
+++ b/src/ServiceProviders/ConfigServiceProvider.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/ServiceProviders/DbServiceProvider.php
+++ b/src/ServiceProviders/DbServiceProvider.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/ServiceProviders/LogServiceProvider.php
+++ b/src/ServiceProviders/LogServiceProvider.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/ServiceProviders/RequestServiceProvider.php
+++ b/src/ServiceProviders/RequestServiceProvider.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/ServiceProviders/SettingsServiceProvider.php
+++ b/src/ServiceProviders/SettingsServiceProvider.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/ServiceProviders/SphinxServiceProvider.php
+++ b/src/ServiceProviders/SphinxServiceProvider.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/ServiceProviders/TranslationServiceProvider.php
+++ b/src/ServiceProviders/TranslationServiceProvider.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/ServiceProviders/TwigServiceProvider.php
+++ b/src/ServiceProviders/TwigServiceProvider.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/ServiceProviders/ViewServiceProvider.php
+++ b/src/ServiceProviders/ViewServiceProvider.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/ServiceProviders/VisitorServiceProvider.php
+++ b/src/ServiceProviders/VisitorServiceProvider.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/Twig/Loader/Filesystem.php
+++ b/src/Twig/Loader/Filesystem.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/View.php
+++ b/src/View.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/Visitor.php
+++ b/src/Visitor.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/styleguide.php
+++ b/styleguide.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/terms.php
+++ b/terms.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tests/src/Cache/AdapterTest.php
+++ b/tests/src/Cache/AdapterTest.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tests/src/Cache/FileAdapterTest.php
+++ b/tests/src/Cache/FileAdapterTest.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tests/src/Cache/MemoryAdapterTest.php
+++ b/tests/src/Cache/MemoryAdapterTest.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tests/src/ConfigTest.php
+++ b/tests/src/ConfigTest.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tests/src/Db/AdapterTest.php
+++ b/tests/src/Db/AdapterTest.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tests/src/DiTest.php
+++ b/tests/src/DiTest.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tests/src/LogTest.php
+++ b/tests/src/LogTest.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tests/src/ServiceProviders/CaptchaServiceProviderTest.php
+++ b/tests/src/ServiceProviders/CaptchaServiceProviderTest.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tests/src/ServiceProviders/RequestServiceProviderTest.php
+++ b/tests/src/ServiceProviders/RequestServiceProviderTest.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tests/src/ServiceProviders/ViewServiceProviderTest.php
+++ b/tests/src/ServiceProviders/ViewServiceProviderTest.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tests/src/ViewTest.php
+++ b/tests/src/ViewTest.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tracker.php
+++ b/tracker.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/viewforum.php
+++ b/viewforum.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/viewtopic.php
+++ b/viewtopic.php
@@ -2,7 +2,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2005-2016 TorrentPier
+ * Copyright (c) 2005-2017 TorrentPier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Мелкое исправление, в виде банального обновления года в тексте MIT лицензии. Необходимо для более корректного сравнения с master-бранчем, где год уже текущий.