### PR TITLE
Tidy deprecated option merge-spans remove

### DIFF
--- a/library/config.php
+++ b/library/config.php
@@ -97,9 +97,9 @@ $domain_name = 'torrentpier.me'; // enter here your primary domain name of your 
 $domain_name = (!empty($_SERVER['SERVER_NAME'])) ? $_SERVER['SERVER_NAME'] : $domain_name;
 
 // Version info
-$bb_cfg['tp_version'] = '2.1.5';
-$bb_cfg['tp_release_date'] = '06-12-2014';
-$bb_cfg['tp_release_state'] = 'ALPHA';
+$bb_cfg['tp_version'] = '2.1.6';
+$bb_cfg['tp_release_date'] = '**-02-2017';
+$bb_cfg['tp_release_state'] = 'STABLE';
 $bb_cfg['tp_zf_version'] = '2.3.3';
 
 // Database

--- a/library/includes/bbcode.php
+++ b/library/includes/bbcode.php
@@ -437,7 +437,6 @@ class bbcode
         'join-classes' => false,
         'join-styles' => false,
         'merge-divs' => false,
-        'merge-spans' => false,
         'newline' => 'LF',
         'output-xhtml' => true,
         'preserve-entities' => true,


### PR DESCRIPTION
[Баг-репорт на форуме](https://torrentpier.me/forum/threads/tidy_repair_string.35429/).

Исправление ошибки, вызванной устаревшей deprecated опцией в tidy. В связи с достаточно высокой вероятностью ошибки в работе опции, она была просто удалена, равно как и у нас. 

Дополнительно связанная правка с корректировкой версии в master-бранче.