### PR TITLE
Poster birthday with no birthday date fix

### DIFF
--- a/viewtopic.php
+++ b/viewtopic.php
@@ -594,7 +594,7 @@ $this_date = bb_date(TIMENOW, 'md', false);
 for ($i = 0; $i < $total_posts; $i++) {
     $poster_id = $postrow[$i]['user_id'];
     $poster = ($poster_id == GUEST_UID) ? $lang['GUEST'] : $postrow[$i]['username'];
-    $poster_birthday = ($poster_id != GUEST_UID) ? date('md', strtotime($postrow[$i]['user_birthday'])) : '';
+    $poster_birthday = ($poster_id != GUEST_UID && $postrow[$i]['user_birthday'] != '0000-00-00') ? date('md', strtotime($postrow[$i]['user_birthday'])) : '';
     $post_date = bb_date($postrow[$i]['post_time'], $bb_cfg['post_date_format']);
     $max_post_time = max($max_post_time, $postrow[$i]['post_time']);
     $poster_posts = ($poster_id != GUEST_UID) ? $postrow[$i]['user_posts'] : '';


### PR DESCRIPTION
[Баг-репорт на форуме](https://torrentpier.me/forum/threads/u-vsex-juzerov-tort-v-postax.30533/).

Исправление ошибки, вызванной тем, что если у пользователя не указана дата рождения, из-за текущей работы с датами не по юникстайму, функция выводящая торт в сообщениях будет выводить ее для всех в определенные дни месяца. В связи с тем, что связанные правки по переводу всего master-бранча на новую работу с датами не целесообразны, решение в виде добавления дополнительной проверки.