### PR TITLE
Fix default users language in dump

### DIFF
--- a/install/sql/mysql.sql
+++ b/install/sql/mysql.sql
@@ -1329,21 +1329,21 @@ CREATE TABLE IF NOT EXISTS `bb_users` (
 -- Records of bb_users
 -- ----------------------------
 INSERT INTO `bb_users` VALUES
-  ('-1', '0', 'Guest', 'd41d8cd98f00b204e9800998ecf8427e', '0', '0', '0', UNIX_TIMESTAMP(), '0', '0', '0', '', '', '0',
+  ('-1', '0', 'Guest', 'd41d8cd98f00b204e9800998ecf8427e', '0', '0', '0', UNIX_TIMESTAMP(), '0', '0', '0', '', 'ru', '0',
                                                                                                            '0', '0',
                                                                                                            '0', '0',
                                                                                                            '0', '0',
                                                                                                            '0000-00-00',
     '', '', '', '', '', '', '', '', '', '', '', '', '0', '0.00', 'default');
 INSERT INTO `bb_users` VALUES
-  ('-746', '0', 'bot', 'd41d8cd98f00b204e9800998ecf8427e', '0', '0', '0', UNIX_TIMESTAMP(), '0', '0', '0', '', '', '0',
+  ('-746', '0', 'bot', 'd41d8cd98f00b204e9800998ecf8427e', '0', '0', '0', UNIX_TIMESTAMP(), '0', '0', '0', '', 'ru', '0',
                                                                                                            '0', '0',
                                                                                                            '144', '0',
                                                                                                            '0', '0',
                                                                                                            '0000-00-00',
     'bot@torrentpier.me', '', '', '', '', '', '', '', '', '', '', '', '0', '0.00', 'default');
 INSERT INTO `bb_users` VALUES
-  ('2', '1', 'admin', 'c3284d0f94606de1fd2af172aba15bf3', '0', '0', '0', UNIX_TIMESTAMP(), '0', '1', '1', '', '', '0',
+  ('2', '1', 'admin', 'c3284d0f94606de1fd2af172aba15bf3', '0', '0', '0', UNIX_TIMESTAMP(), '0', '1', '1', '', 'ru', '0',
                                                                                                           '0', '0',
                                                                                                           '304', '1',
                                                                                                           '0', '0',


### PR DESCRIPTION
Установка языка стандартным пользователям в дампе. В связи с тем, что язык форума по-умолчанию ставится русский, тут аналогично.