### PR TITLE
PHP 7+ as minimal requirement for new version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ and go from there. The documentation will be translated into english in the near
 
 * Apache / nginx
 * MySQL / MariaDB / Percona
-* PHP: 5.6 / 7.0 / 7.1
+* PHP: 7.0 / 7.1 / 7.2
 * PHP Extensions: bcmath, intl, tidy (optional)
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "docs": "https://docs.torrentpier.me/"
   },
   "require": {
-    "php": "^5.6 || ^7.0",
+    "php": "^7.0",
     "bugsnag/bugsnag": "^3.5",
     "filp/whoops": "^2.1",
     "gigablah/sphinxphp": "^2.0",

--- a/library/includes/init_bb.php
+++ b/library/includes/init_bb.php
@@ -30,8 +30,8 @@ if (!defined('BB_ROOT')) {
 /**
  * Check PHP version
  */
-if (version_compare(PHP_VERSION, '5.6', '<')) {
-    die('TorrentPier requires PHP version 5.6+. Your PHP version ' . PHP_VERSION);
+if (version_compare(PHP_VERSION, '7.0', '<')) {
+    die('TorrentPier requires PHP version 7.0+. Your PHP version ' . PHP_VERSION);
 }
 
 /**


### PR DESCRIPTION
Повышение минимально требуемой версии PHP для новой версии.