### PR TITLE
Disable Bugsnag by default

### DIFF
--- a/common.php
+++ b/common.php
@@ -151,17 +151,19 @@ define('BOT_UID', -746);
 /**
  * Progressive error reporting
  */
-if ($bb_cfg['bugsnag']['enabled'] && env('APP_ENV', 'production') !== 'local') {
-    /** @var Bugsnag\Handler $bugsnag */
-    $bugsnag = Bugsnag\Client::make($bb_cfg['bugsnag']['api_key']);
-    Bugsnag\Handler::register($bugsnag);
-}
-
-if (DBG_USER && env('APP_ENV', 'production') === 'local') {
-    /** @var Whoops\Run $whoops */
-    $whoops = new \Whoops\Run;
-    $whoops->pushHandler(new \Whoops\Handler\PrettyPageHandler);
-    $whoops->register();
+if ($bb_cfg['bugsnag']['enabled']) {
+    if (env('APP_ENV', 'production') !== 'local') {
+        /** @var Bugsnag\Handler $bugsnag */
+        $bugsnag = Bugsnag\Client::make($bb_cfg['bugsnag']['api_key']);
+        Bugsnag\Handler::register($bugsnag);
+    }
+} else {
+    if (DBG_USER) {
+        /** @var Whoops\Run $whoops */
+        $whoops = new \Whoops\Run;
+        $whoops->pushHandler(new \Whoops\Handler\PrettyPageHandler);
+        $whoops->register();
+    }
 }
 
 /**

--- a/library/config.php
+++ b/library/config.php
@@ -415,7 +415,7 @@ $bb_cfg['adv_email'] = "adv@$domain_name";
 
 // Bugsnag error reporting
 $bb_cfg['bugsnag'] = [
-    'enabled' => true,
+    'enabled' => false,
     'api_key' => 'ee1adc9739cfceb01ce4a450ae1e52bf',
 ];
 


### PR DESCRIPTION
Отключение сбора ошибок в Bugsnag по-умолчанию из-за сложностей с адаптацией модификаций у пользователей.