### PR TITLE
Display source language if no user language variable

### DIFF
--- a/src/Helpers/CronHelper.php
+++ b/src/Helpers/CronHelper.php
@@ -53,7 +53,9 @@ class CronHelper
      */
     public static function releaseLockFile()
     {
-        rename(CRON_RUNNING, CRON_ALLOWED);
+        if (file_exists(CRON_RUNNING)) {
+            rename(CRON_RUNNING, CRON_ALLOWED);
+        }
         self::touchLockFile(CRON_ALLOWED);
     }
 

--- a/src/Legacy/Common/User.php
+++ b/src/Legacy/Common/User.php
@@ -571,14 +571,14 @@ class User
      */
     public function init_userprefs()
     {
-        global $bb_cfg, $theme, $lang, $DeltaTime;
+        global $bb_cfg, $theme, $source_lang, $DeltaTime;
 
         if (defined('LANG_DIR')) {
             return;
         }  // prevent multiple calling
 
         define('DEFAULT_LANG_DIR', LANG_ROOT_DIR . '/' . $bb_cfg['default_lang'] . '/');
-        define('ENGLISH_LANG_DIR', LANG_ROOT_DIR . '/en/');
+        define('SOURCE_LANG_DIR', LANG_ROOT_DIR . '/source/');
 
         if ($this->data['user_id'] != GUEST_UID) {
             if ($this->data['user_lang'] && $this->data['user_lang'] != $bb_cfg['default_lang']) {
@@ -598,6 +598,14 @@ class User
             define('LANG_DIR', DEFAULT_LANG_DIR);
         }
 
+        /** Temporary place source language to the global */
+        $lang = [];
+        require(SOURCE_LANG_DIR . 'main.php');
+        $source_lang = $lang;
+        unset($lang);
+
+        /** Place user language to the global */
+        global $lang;
         require(LANG_DIR . 'main.php');
         setlocale(LC_ALL, isset($bb_cfg['lang'][$this->data['user_lang']]['locale']) ?
             $bb_cfg['lang'][$this->data['user_lang']]['locale'] : 'en_US.UTF-8');

--- a/src/Legacy/Template.php
+++ b/src/Legacy/Template.php
@@ -239,10 +239,11 @@ class Template
     {
         $this->cur_tpl = $filename;
 
-        global $lang, $bb_cfg, $user;
+        global $lang, $source_lang, $bb_cfg, $user;
 
         $L =& $lang;
         $V =& $this->vars;
+        $SL =& $source_lang;
 
         if ($filename) {
             include $filename;
@@ -773,7 +774,7 @@ class Template
             $code = str_replace($search, $replace, $code);
         }
         // This will handle the remaining root-level varrefs
-        $code = preg_replace('#\{(L_([a-z0-9\-_]+?))\}#i', '<?php echo isset($L[\'$2\']) ? $L[\'$2\'] : $V[\'$1\']; ?>', $code);
+        $code = preg_replace('#\{(L_([a-z0-9\-_]+?))\}#i', '<?php echo isset($L[\'$2\']) ? $L[\'$2\'] : (isset($SL[\'$2\']) ? $SL[\'$2\'] : \'$2\'); ?>', $code);
         $code = preg_replace('#\{(\$[a-z_][a-z0-9_$\->\'\"\.\[\]]*?)\}#i', '<?php echo isset($1) ? $1 : \'\'; ?>', $code);
         $code = preg_replace('#\{(\#([a-z_][a-z0-9_]*?))\}#i', '<?php echo defined(\'$2\') ? $2 : \'\'; ?>', $code);
         $code = preg_replace('#\{([a-z0-9\-_]+?)\}#i', '<?php echo isset($V[\'$1\']) ? $V[\'$1\'] : \'\'; ?>', $code);


### PR DESCRIPTION
Достаточно костыльное исправление ошибки при отсутствии языковых переменных в языке пользователя. Если нет переменной в языке пользователя - проверка на наличие оной в source-языке, иначе вывод переменной без обработки.