### PR TITLE
Update .htaccess for new Apache 2.4 syntax.

### DIFF
--- a/bt/includes/.htaccess
+++ b/bt/includes/.htaccess
@@ -1,2 +1,1 @@
-order allow,deny
-deny from all
+Require all denied

--- a/install/.htaccess
+++ b/install/.htaccess
@@ -1,2 +1,1 @@
-order allow,deny
-deny from all
+Require all denied

--- a/internal_data/cache/.htaccess
+++ b/internal_data/cache/.htaccess
@@ -1,2 +1,1 @@
-order allow,deny
-deny from all
+Require all denied

--- a/internal_data/log/.htaccess
+++ b/internal_data/log/.htaccess
@@ -1,2 +1,1 @@
-order allow,deny
-deny from all
+Require all denied

--- a/internal_data/log/cron/.htaccess
+++ b/internal_data/log/cron/.htaccess
@@ -1,2 +1,1 @@
-order allow,deny
-deny from all
+Require all denied

--- a/internal_data/triggers/.htaccess
+++ b/internal_data/triggers/.htaccess
@@ -1,2 +1,1 @@
-order allow,deny
-deny from all
+Require all denied

--- a/library/attach_mod/.htaccess
+++ b/library/attach_mod/.htaccess
@@ -1,2 +1,1 @@
-order allow,deny
-deny from all
+Require all denied

--- a/library/attach_mod/includes/.htaccess
+++ b/library/attach_mod/includes/.htaccess
@@ -1,2 +1,1 @@
-order allow,deny
-deny from all
+Require all denied

--- a/library/config.php
+++ b/library/config.php
@@ -36,8 +36,8 @@ $bb_cfg = [];
 $bb_cfg['js_ver'] = $bb_cfg['css_ver'] = 1;
 
 // Version info
-$bb_cfg['tp_version'] = '2.2.2';
-$bb_cfg['tp_release_date'] = '23-06-2017';
+$bb_cfg['tp_version'] = '2.2.3';
+$bb_cfg['tp_release_date'] = '07-08-2017';
 $bb_cfg['tp_release_codename'] = 'Aurochs';
 
 // Database

--- a/library/includes/.htaccess
+++ b/library/includes/.htaccess
@@ -1,2 +1,1 @@
-order allow,deny
-deny from all
+Require all denied


### PR DESCRIPTION
The `Allow`, `Deny`, and `Order` directives, provided by `mod_access_compat`, are deprecated and will go away in a future version. You should avoid using them, and avoid outdated tutorials recommending their use.