### PR TITLE
Add back roave/security-advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
     "gigablah/sphinxphp": "^2.0",
     "google/recaptcha": "^1.1",
     "longman/ip-tools": "^1.2",
+    "roave/security-advisories": "dev-master",
     "rych/bencode": "^1.0",
     "samdark/sitemap": "^2.0",
     "swiftmailer/swiftmailer": "^5.4",


### PR DESCRIPTION
Add it back as otherwise tests with --prefer-lowest will fail. Closes #445 