### PR TITLE
Default value for user_birthday causes exception on user password change

### DIFF
--- a/index.php
+++ b/index.php
@@ -379,7 +379,7 @@ if ($bb_cfg['birthday_check_day'] && $bb_cfg['birthday_enabled']) {
                 $week_all = true;
                 continue;
             }
-            $week_list[] = profile_url($week) . ' <span class="small">(' . birthday_age($week['user_birthday'] - 1) . ')</span>';
+            $week_list[] = profile_url($week) . ' <span class="small">(' . birthday_age($week['user_birthday']) . ')</span>';
         }
         $week_all = ($week_all) ? '&nbsp;<a class="txtb" href="#" onclick="ajax.exec({action: \'index_data\', mode: \'birthday_week\'}); return false;" title="' . $lang['ALL'] . '">...</a>' : '';
         $week_list = sprintf($lang['BIRTHDAY_WEEK'], $bb_cfg['birthday_check_day'], implode(', ', $week_list)) . $week_all;

--- a/library/includes/datastore/build_stats.php
+++ b/library/includes/datastore/build_stats.php
@@ -76,6 +76,7 @@ if ($bb_cfg['birthday_check_day'] && $bb_cfg['birthday_enabled']) {
 		FROM " . BB_USERS . "
 		WHERE user_id NOT IN(" . EXCLUDED_USERS . ")
 			AND user_birthday != '0000-00-00'
+			AND user_birthday IS NOT NULL
 			AND user_active = 1
 		ORDER BY user_level DESC, username
 	");

--- a/library/includes/ucp/register.php
+++ b/library/includes/ucp/register.php
@@ -321,9 +321,9 @@ foreach ($profile_fields as $field => $can_edit) {
          *  Возраст (edit)
          */
         case 'user_birthday':
-            $user_birthday = isset($_POST['user_birthday']) ? (string)$_POST['user_birthday'] : $pr_data['user_birthday'];
+            $user_birthday = !empty($_POST['user_birthday']) ? (string)$_POST['user_birthday'] : $pr_data['user_birthday'];
 
-            if ($submit && $user_birthday != $pr_data['user_birthday']) {
+            if ($submit && $user_birthday !== $pr_data['user_birthday']) {
                 $birthday_date = date_parse($user_birthday);
 
                 if (!empty($birthday_date['year'])) {
@@ -336,8 +336,7 @@ foreach ($profile_fields as $field => $can_edit) {
                     }
                 }
 
-                $pr_data['user_birthday'] = $user_birthday;
-                $db_data['user_birthday'] = $user_birthday;
+                $pr_data['user_birthday'] = $db_data['user_birthday'] = !empty($user_birthday) ? $user_birthday : null;
             }
             $tp_data['USER_BIRTHDAY'] = $pr_data['user_birthday'];
             break;

--- a/library/includes/ucp/viewprofile.php
+++ b/library/includes/ucp/viewprofile.php
@@ -114,8 +114,8 @@ $template->assign_vars(array(
     'TWITTER' => $profiledata['user_twitter'],
     'USER_POINTS' => $profiledata['user_points'],
     'GENDER' => ($bb_cfg['gender']) ? $lang['GENDER_SELECT'][$profiledata['user_gender']] : '',
-    'BIRTHDAY' => ($bb_cfg['birthday_enabled'] && $profiledata['user_birthday'] != '0000-00-00') ? $profiledata['user_birthday'] : '',
-    'AGE' => ($bb_cfg['birthday_enabled'] && $profiledata['user_birthday'] != '0000-00-00') ? birthday_age($profiledata['user_birthday']) : '',
+    'BIRTHDAY' => ($bb_cfg['birthday_enabled'] && !empty($profiledata['user_birthday']) && $profiledata['user_birthday'] != '0000-00-00') ? $profiledata['user_birthday'] : '',
+    'AGE' => ($bb_cfg['birthday_enabled'] && !empty($profiledata['user_birthday']) && $profiledata['user_birthday'] != '0000-00-00') ? birthday_age($profiledata['user_birthday']) : '',
 
     'L_VIEWING_PROFILE' => sprintf($lang['VIEWING_USER_PROFILE'], $profiledata['username']),
     'L_MY_PROFILE' => sprintf($lang['VIEWING_MY_PROFILE'], 'profile.php?mode=editprofile'),

--- a/viewtopic.php
+++ b/viewtopic.php
@@ -587,7 +587,8 @@ $this_date = bb_date(TIMENOW, 'md', false);
 for ($i = 0; $i < $total_posts; $i++) {
     $poster_id = $postrow[$i]['user_id'];
     $poster = ($poster_id == GUEST_UID) ? $lang['GUEST'] : $postrow[$i]['username'];
-    $poster_birthday = ($poster_id != GUEST_UID && $postrow[$i]['user_birthday'] != '0000-00-00') ? date('md', strtotime($postrow[$i]['user_birthday'])) : '';
+    $poster_birthday = ($poster_id != GUEST_UID && !empty($postrow[$i]['user_birthday']) && $postrow[$i]['user_birthday'] != '0000-00-00')
+        ? date('md', strtotime($postrow[$i]['user_birthday'])) : '';
     $post_date = bb_date($postrow[$i]['post_time'], $bb_cfg['post_date_format']);
     $max_post_time = max($max_post_time, $postrow[$i]['post_time']);
     $poster_posts = ($poster_id != GUEST_UID) ? $postrow[$i]['user_posts'] : '';


### PR DESCRIPTION
```
Whoops\Exception\ErrorException thrown with message "DB Error [library/includes/ucp/register.php(655)]"

Stacktrace:
#4 Whoops\Exception\ErrorException in /var/www/html/src/Legacy/SqlDb.php:859
#3 trigger_error in /var/www/html/src/Legacy/SqlDb.php:859
#2 TorrentPier\Legacy\SqlDb:trigger_error in /var/www/html/src/Legacy/SqlDb.php:180
#1 TorrentPier\Legacy\SqlDb:query in /var/www/html/library/includes/ucp/register.php:655
#0 require in /var/www/html/profile.php:47
```
* Side note: on InnoDB there's no point in storing exact values - there's no extra space required to store NULL;
* After user's registration `user_birthday` is set to default `0000-00-00`, which itself is wrong value for date;
* If user attempts to change password without setting date, TP2 will try to store `''` (empty string) as a date:
```
UPDATE bb_users SET \n
user_password = '8b283e8957f744ae5a1a6add05fc354f',\n
user_birthday = '',\n
user_sig = ''\n
 WHERE user_id = 2
```

Also fixes #447 