### PR TITLE
Fixed PHP 7.3: Deprecate FILTER_FLAG_SCHEME_REQUIRED and FILTER_FLAG_…

### DIFF
--- a/src/Legacy/Sitemap.php
+++ b/src/Legacy/Sitemap.php
@@ -95,7 +95,7 @@ class Sitemap
             $urls = explode("\n", $bb_cfg['static_sitemap']);
             foreach ($urls as $url) {
                 /** @var string $url проверяем что адрес валиден и с указанными протоколом */
-                if (filter_var(trim($url), FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED)) {
+                if (filter_var(trim($url), FILTER_VALIDATE_URL)) {
                     $staticUrls[] = [
                         'url' => trim($url),
                     ];


### PR DESCRIPTION
PHP 7.3: Deprecate FILTER_FLAG_SCHEME_REQUIRED and FILTER_FLAG_HOST_REQUIRED flags used with FILTER_VALIDATE_URL

https://php.watch/versions/7.3/filter-var-flag-deprecation