### PR TITLE
Fixed SQLite caching issue

### DIFF
--- a/src/Legacy/Cache/Sqlite.php
+++ b/src/Legacy/Cache/Sqlite.php
@@ -59,7 +59,7 @@ class Sqlite extends Common
 			SELECT cache_name, cache_value
 			FROM " . $this->cfg['table_name'] . "
 			WHERE cache_name IN('$this->prefix_sql" . implode("','$this->prefix_sql", $name_sql) . "') AND cache_expire_time > " . TIMENOW . "
-			LIMIT " . \count($name) . "
+			LIMIT " . \count($name_sql) . "
 		");
 
         $this->db->debug('start', 'unserialize()');


### PR DESCRIPTION
* count(): Parameter must be an array or an object that implements Countable

* It happens because of in PHP 7.2 NULL in count() return Warning