### PR TITLE
Set SQL_MODE = "" as GLOBAL

### DIFF
--- a/install/sql/mysql.sql
+++ b/install/sql/mysql.sql
@@ -1,4 +1,4 @@
-SET SQL_MODE = "";
+SET GLOBAL SQL_MODE = "";
 
 -- ----------------------------
 -- Table structure for `bb_attachments`

--- a/install/sql/ocelot.sql
+++ b/install/sql/ocelot.sql
@@ -1,4 +1,4 @@
-SET SQL_MODE = "";
+SET GLOBAL SQL_MODE = "";
 
 -- ----------------------------
 -- Table structure for `bb_bt_tracker`

--- a/install/upgrade/changes.txt
+++ b/install/upgrade/changes.txt
@@ -43,3 +43,6 @@ ALTER TABLE `bb_posts` CHANGE `mc_comment` `mc_comment` TEXT NOT NULL DEFAULT ''
 ALTER TABLE `bb_users` CHANGE `user_sig` `user_sig` TEXT NOT NULL DEFAULT '';
 ALTER TABLE `bb_groups` CHANGE `group_signature` `group_signature` TEXT NOT NULL DEFAULT '';
 ALTER TABLE `bb_groups` CHANGE `group_description` `group_description` TEXT NOT NULL DEFAULT '';
+
+// 2.3.0.4
+SET GLOBAL SQL_MODE = "";


### PR DESCRIPTION
Устанавливает SQL_MODE = "" глобально. В противном случае (как было раннее) данный запрос не работает должным образом.

Так же это исправляет проблему (возможно и в других местах тоже) при выполнении крон задачи **tr_cleanup_and_dlstat.php** на MySQL 8.0.

Лог:
`#001055 Expression #3 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'torrentpier.bb_bt_tracker.releaser' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by`

https://stackoverflow.com/questions/41887460/select-list-is-not-in-group-by-clause-and-contains-nonaggregated-column-inc