### PR TITLE
Added nedeed "ORDER BY" in sql query

### DIFF
--- a/admin/stats/tracker.php
+++ b/admin/stats/tracker.php
@@ -67,7 +67,7 @@ foreach ($peers_in_last_minutes as $t) {
 }
 // Last xx seconds
 $peers_in_last_sec = array();
-$rowset = DB()->fetch_rowset('SELECT COUNT(*) AS peers FROM ' . TMP_TRACKER_TABLE . ' GROUP BY update_time ORDER BY update_time DESC LIMIT' . " $peers_in_last_sec_limit");
+$rowset = DB()->fetch_rowset('SELECT COUNT(*) AS peers FROM ' . TMP_TRACKER_TABLE . ' GROUP BY update_time ORDER BY update_time DESC LIMIT ' . $peers_in_last_sec_limit);
 foreach ($rowset as $cnt => $row) {
     $peers_in_last_sec[] = sprintf('%3s', $row['peers']) . (($cnt && !(++$cnt % 15)) ? "  \n" : '');
 }

--- a/admin/stats/tracker.php
+++ b/admin/stats/tracker.php
@@ -67,7 +67,7 @@ foreach ($peers_in_last_minutes as $t) {
 }
 // Last xx seconds
 $peers_in_last_sec = array();
-$rowset = DB()->fetch_rowset('SELECT COUNT(*) AS peers FROM ' . TMP_TRACKER_TABLE . " GROUP BY update_time DESC LIMIT $peers_in_last_sec_limit");
+$rowset = DB()->fetch_rowset('SELECT COUNT(*) AS peers FROM ' . TMP_TRACKER_TABLE . ' GROUP BY update_time ORDER BY update_time DESC LIMIT' . " $peers_in_last_sec_limit");
 foreach ($rowset as $cnt => $row) {
     $peers_in_last_sec[] = sprintf('%3s', $row['peers']) . (($cnt && !(++$cnt % 15)) ? "  \n" : '');
 }


### PR DESCRIPTION
Исправлена ошибка которая возникает в файле **admin/stats/tracker.php** (MySQL 8.0).

Лог:
```
#001064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'DESC LIMIT 300' at line 1

SELECT COUNT(*) AS peers FROM tmp_tracker GROUP BY update_time DESC LIMIT 300

Source  : admin\stats\tracker.php(71) :: db.torrentpier
IP      : 127.0.0.1
Date    : 2023-03-02 19:01:18
Agent   : Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36
Req_URI : /admin/stats/tracker.php
Referer : http://localhost/admin/index.php?pane=right
Method  : GET
```

https://dev.mysql.com/doc/refman/8.0/en/select.html
https://stackoverflow.com/questions/53846308/group-by-desc-syntax-error-on-mysql-8-0-which-is-fine-on-5-7