### PR TITLE
Fixed undefined $subject in register.php

### DIFF
--- a/library/includes/ucp/register.php
+++ b/library/includes/ucp/register.php
@@ -609,7 +609,6 @@ if ($submit && !$errors) {
 
                 $emailer->set_from([$bb_cfg['board_email'] => $bb_cfg['sitename']]);
                 $emailer->set_to([$email => $username]);
-                $emailer->set_subject($subject);
                 $emailer->set_subject($lang['EMAILER_SUBJECT']['USER_ACTIVATE']);
 
                 $emailer->set_template('user_activate', $pr_data['user_lang']);


### PR DESCRIPTION
Переменная $subject нигде не объявлена, это приводит к ошибке при редактировании пользователя с не активированным аккаунтом. К тому же, метод set_subject уже объявлен ниже в коде.

https://torrentpier.com/threads/undefined-variable-subject.42094/