### PR TITLE
Fixed broken predicting birthday year

### DIFF
--- a/index.php
+++ b/index.php
@@ -363,7 +363,7 @@ if ($bb_cfg['birthday_check_day'] && $bb_cfg['birthday_enabled']) {
                 $week_all = true;
                 continue;
             }
-            $week_list[] = profile_url($week) . ' <span class="small">(' . birthday_age($week['user_birthday']) . ')</span>';
+            $week_list[] = profile_url($week) . ' <span class="small">(' . birthday_age(date('Y-m-d', strtotime('-1 year', strtotime($week['user_birthday'])))) . ')</span>';
         }
         $week_all = $week_all ? '&nbsp;<a class="txtb" href="#" onclick="ajax.exec({action: \'index_data\', mode: \'birthday_week\'}); return false;" title="' . $lang['ALL'] . '">...</a>' : '';
         $week_list = sprintf($lang['BIRTHDAY_WEEK'], $bb_cfg['birthday_check_day'], implode(', ', $week_list)) . $week_all;

--- a/library/ajax/index_data.php
+++ b/library/ajax/index_data.php
@@ -27,7 +27,7 @@ switch ($mode) {
 
         if ($stats['birthday_week_list']) {
             foreach ($stats['birthday_week_list'] as $week) {
-                $users[] = profile_url($week) . ' <span class="small">(' . birthday_age($week['user_birthday']) . ')</span>';
+                $users[] = profile_url($week) . ' <span class="small">(' . birthday_age(date('Y-m-d', strtotime('-1 year', strtotime($week['user_birthday'])))) . ')</span>';
             }
             $html = sprintf($lang['BIRTHDAY_WEEK'], $bb_cfg['birthday_check_day'], implode(', ', $users));
         } else {


### PR DESCRIPTION
Исправляет отображение возраста пользователей у которых будет день рождения на этой неделе.
То-есть ранее у нас был вывод просто текущего возраста `$week['user_birthday']`  а не возраста который БУДЕТ (то-есть сколько исполнится). Через отнимание одного года от даты удалось исправить вывод.

Пример:
![Снимок](https://user-images.githubusercontent.com/54049465/228741141-6467e043-59bd-4ee9-a1ce-ec240e0cfd61.PNG)
![Снимок123](https://user-images.githubusercontent.com/54049465/228741157-fa11b7be-216a-4830-b2e3-f99c6b4f50fd.PNG)

Кстати, ранее подобный код (https://github.com/torrentpier/torrentpier/pull/449/commits/a6ab8ac4310fea4354dd6b11883c6abb9e97a11b) уже был в движке, но он не работал, т. к просто было отнимание единицы от datetime строки )))
