### PR TITLE
Fixed: preg_match(): Passing null to parameter #2 ($subject) of type …

### DIFF
--- a/src/Legacy/Template.php
+++ b/src/Legacy/Template.php
@@ -793,6 +793,7 @@ class Template
 
         for ($i = 0; $i < $tokens_cnt; $i++) {
             $token = &$tokens[$i];
+            $token = $token ?? '';
 
             switch ($token) {
                 case 'eq':


### PR DESCRIPTION
…string is deprecated