### PR TITLE
Improve SQL queries in online_userlist.php and tr_cleanup_and_dlstat.php

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3746,6 +3746,6 @@
     "platform": {
         "php": ">=8.1"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/library/includes/cron/jobs/tr_cleanup_and_dlstat.php
+++ b/library/includes/cron/jobs/tr_cleanup_and_dlstat.php
@@ -39,7 +39,7 @@ if ($bb_cfg['tracker']['update_dlstat']) {
 		INSERT INTO " . NEW_BB_BT_LAST_TORSTAT . "
 			(topic_id, user_id, dl_status, up_add, down_add, release_add, speed_up, speed_down)
 		SELECT
-			topic_id, user_id, IF(releaser, $releaser, seeder), SUM(up_add), SUM(down_add), IF(releaser, SUM(up_add), 0), SUM(speed_up), SUM(speed_down)
+			topic_id, user_id, IF(MAX(releaser), $releaser, seeder), SUM(up_add), SUM(down_add), IF(MAX(releaser), SUM(up_add), 0), SUM(speed_up), SUM(speed_down)
 		FROM " . BB_BT_TRACKER . "
 		WHERE (up_add != 0 OR down_add != 0)
 		GROUP BY topic_id, user_id

--- a/library/includes/online_userlist.php
+++ b/library/includes/online_userlist.php
@@ -36,11 +36,11 @@ $online = $online_short = ['userlist' => ''];
 $sql = "
 	SELECT
 		u.username, u.user_id, u.user_opt, u.user_rank, u.user_level,
-		s.session_logged_in, s.session_ip, (s.session_time - s.session_start) AS ses_len, COUNT(s.session_id) AS sessions, COUNT(DISTINCT s.session_ip) AS ips
+		MAX(s.session_logged_in) AS session_logged_in, MAX(s.session_ip) AS session_ip, MAX(s.session_time - s.session_start) AS ses_len, COUNT(s.session_id) AS sessions, COUNT(DISTINCT s.session_ip) AS ips
 	FROM " . BB_SESSIONS . " s, " . BB_USERS . " u
 	WHERE s.session_time > $time_online
 		AND u.user_id = s.session_user_id
-	GROUP BY s.session_user_id
+	GROUP BY s.session_user_id, u.username, u.user_id, u.user_opt, u.user_rank, u.user_level
 	ORDER BY u.username
 ";
 


### PR DESCRIPTION
SQL query that selects session_logged_in (among other columns) but only groups by session_user_id. This violates MySQL's only_full_group_by mode because session_logged_in is not in the GROUP BY clause and isn't aggregated.

- Updated plugin API version in composer.lock from 2.3.0 to 2.6.0.
- Modified SQL queries in online_userlist.php to use MAX() for session data and adjusted GROUP BY clause for better accuracy.
- Enhanced SQL logic in tr_cleanup_and_dlstat.php to utilize MAX() for determining the releaser status.

