### PR TITLE
refactor(censor): migrate Censor class to singleton pattern

### DIFF
--- a/admin/admin_words.php
+++ b/admin/admin_words.php
@@ -81,6 +81,7 @@ if ($mode != '') {
         }
 
         $datastore->update('censor');
+        censor()->reload(); // Reload the singleton instance with updated words
         $message .= '<br /><br />' . sprintf($lang['CLICK_RETURN_WORDADMIN'], '<a href="admin_words.php">', '</a>') . '<br /><br />' . sprintf($lang['CLICK_RETURN_ADMIN_INDEX'], '<a href="index.php?pane=right">', '</a>');
 
         bb_die($message);
@@ -95,6 +96,7 @@ if ($mode != '') {
             }
 
             $datastore->update('censor');
+            censor()->reload(); // Reload the singleton instance with updated words
 
             bb_die($lang['WORD_REMOVED'] . '<br /><br />' . sprintf($lang['CLICK_RETURN_WORDADMIN'], '<a href="admin_words.php">', '</a>') . '<br /><br />' . sprintf($lang['CLICK_RETURN_ADMIN_INDEX'], '<a href="index.php?pane=right">', '</a>'));
         } else {

--- a/common.php
+++ b/common.php
@@ -86,7 +86,8 @@ if (is_file(BB_PATH . '/library/config.local.php')) {
     require_once BB_PATH . '/library/config.local.php';
 }
 
-// Initialize Config singleton
+/** @noinspection PhpUndefinedVariableInspection */
+// Initialize Config singleton, bb_cfg from global file config
 $config = \TorrentPier\Config::init($bb_cfg);
 
 /**
@@ -97,6 +98,16 @@ $config = \TorrentPier\Config::init($bb_cfg);
 function config(): \TorrentPier\Config
 {
     return \TorrentPier\Config::getInstance();
+}
+
+/**
+ * Get the Censor instance
+ *
+ * @return \TorrentPier\Censor
+ */
+function censor(): \TorrentPier\Censor
+{
+    return \TorrentPier\Censor::getInstance();
 }
 
 /**

--- a/common.php
+++ b/common.php
@@ -111,6 +111,16 @@ function censor(): \TorrentPier\Censor
 }
 
 /**
+ * Get the Dev instance
+ *
+ * @return \TorrentPier\Dev
+ */
+function dev(): \TorrentPier\Dev
+{
+    return \TorrentPier\Dev::getInstance();
+}
+
+/**
  * Initialize debug
  */
 define('APP_ENV', env('APP_ENV', 'production'));
@@ -119,7 +129,7 @@ if (APP_ENV === 'local') {
 } else {
     define('DBG_USER', isset($_COOKIE[COOKIE_DBG]));
 }
-(new \TorrentPier\Dev());
+(\TorrentPier\Dev::init());
 
 /**
  * Server variables initialize

--- a/index.php
+++ b/index.php
@@ -339,7 +339,7 @@ if (config()->get('show_latest_news')) {
 
         $template->assign_block_vars('news', [
             'NEWS_TOPIC_ID' => $news['topic_id'],
-            'NEWS_TITLE' => str_short($wordCensor->censorString($news['topic_title']), config()->get('max_news_title')),
+            'NEWS_TITLE' => str_short(censor()->censorString($news['topic_title']), config()->get('max_news_title')),
             'NEWS_TIME' => bb_date($news['topic_time'], 'd-M', false),
             'NEWS_IS_NEW' => is_unread($news['topic_time'], $news['topic_id'], $news['forum_id']),
         ]);
@@ -362,7 +362,7 @@ if (config()->get('show_network_news')) {
 
         $template->assign_block_vars('net', [
             'NEWS_TOPIC_ID' => $net['topic_id'],
-            'NEWS_TITLE' => str_short($wordCensor->censorString($net['topic_title']), config()->get('max_net_title')),
+            'NEWS_TITLE' => str_short(censor()->censorString($net['topic_title']), config()->get('max_net_title')),
             'NEWS_TIME' => bb_date($net['topic_time'], 'd-M', false),
             'NEWS_IS_NEW' => is_unread($net['topic_time'], $net['topic_id'], $net['forum_id']),
         ]);

--- a/library/ajax/posts.php
+++ b/library/ajax/posts.php
@@ -11,7 +11,7 @@ if (!defined('IN_AJAX')) {
     die(basename(__FILE__));
 }
 
-global $lang, $userdata, $wordCensor;
+global $lang, $userdata;
 
 if (!isset($this->request['type'])) {
     $this->ajax_die('empty type');
@@ -80,7 +80,7 @@ switch ($this->request['type']) {
         // hide sid
         $message = preg_replace('#(?<=[\?&;]sid=)[a-zA-Z0-9]#', 'sid', $message);
 
-        $message = $wordCensor->censorString($message);
+        $message = censor()->censorString($message);
 
         if ($post['post_id'] == $post['topic_first_post_id']) {
             $message = "[quote]" . $post['topic_title'] . "[/quote]\r";

--- a/library/includes/bbcode.php
+++ b/library/includes/bbcode.php
@@ -401,12 +401,12 @@ function add_search_words($post_id, $post_message, $topic_title = '', $only_retu
 
 function bbcode2html($text)
 {
-    global $bbcode, $wordCensor;
+    global $bbcode;
 
     if (!isset($bbcode)) {
         $bbcode = new TorrentPier\Legacy\BBCode();
     }
-    $text = $wordCensor->censorString($text);
+    $text = censor()->censorString($text);
     return $bbcode->bbcode2html($text);
 }
 

--- a/library/includes/init_bb.php
+++ b/library/includes/init_bb.php
@@ -379,8 +379,10 @@ require_once INC_DIR . '/functions.php';
 config()->merge(bb_get_config(BB_CONFIG));
 $bb_cfg = config()->all();
 
+// wordCensor deprecated, but kept for compatibility with non-adapted code
+$wordCensor = censor();
+
 $log_action = new TorrentPier\Legacy\LogAction();
-$wordCensor = new TorrentPier\Censor();
 $html = new TorrentPier\Legacy\Common\Html();
 $user = new TorrentPier\Legacy\Common\User();
 

--- a/library/includes/page_footer_dev.php
+++ b/library/includes/page_footer_dev.php
@@ -71,7 +71,7 @@ if (!empty($_COOKIE['explain'])) {
     }
 }
 
-$sql_log = !empty($_COOKIE['sql_log']) ? \TorrentPier\Dev::getSqlLog() : false;
+$sql_log = !empty($_COOKIE['sql_log']) ? dev()->getSqlDebugLog() : false;
 
 if ($sql_log) {
     echo '<div class="sqlLog" id="sqlLog">' . $sql_log . '</div><!-- / sqlLog --><br clear="all" />';

--- a/library/includes/ucp/topic_watch.php
+++ b/library/includes/ucp/topic_watch.php
@@ -83,7 +83,7 @@ if ($watch_count > 0) {
                 'ROW_CLASS' => (!($i % 2)) ? 'row1' : 'row2',
                 'POST_ID' => $watch[$i]['topic_first_post_id'],
                 'TOPIC_ID' => $watch[$i]['topic_id'],
-                'TOPIC_TITLE' => str_short($wordCensor->censorString($watch[$i]['topic_title']), 70),
+                'TOPIC_TITLE' => str_short(censor()->censorString($watch[$i]['topic_title']), 70),
                 'FULL_TOPIC_TITLE' => $watch[$i]['topic_title'],
                 'U_TOPIC' => TOPIC_URL . $watch[$i]['topic_id'],
                 'FORUM_TITLE' => $watch[$i]['forum_name'],

--- a/posting.php
+++ b/posting.php
@@ -472,8 +472,8 @@ if ($refresh || $error_msg || ($submit && $topic_has_new_posts)) {
             // hide sid
             $message = preg_replace('#(?<=[\?&;]sid=)[a-zA-Z0-9]#', 'sid', $message);
 
-            $subject = $wordCensor->censorString($subject);
-            $message = $wordCensor->censorString($message);
+            $subject = censor()->censorString($subject);
+            $message = censor()->censorString($message);
 
             if (!preg_match('/^Re:/', $subject) && !empty($subject)) {
                 $subject = 'Re: ' . $subject;

--- a/privmsg.php
+++ b/privmsg.php
@@ -376,8 +376,8 @@ if ($mode == 'read') {
     //
     $post_subject = htmlCHR($privmsg['privmsgs_subject']);
     $private_message = $privmsg['privmsgs_text'];
-    $post_subject = $wordCensor->censorString($post_subject);
-    $private_message = $wordCensor->censorString($private_message);
+    $post_subject = censor()->censorString($post_subject);
+    $private_message = censor()->censorString($private_message);
     $private_message = bbcode2html($private_message);
 
     //
@@ -1044,8 +1044,8 @@ if ($mode == 'read') {
 
     if ($preview && !$error) {
         $preview_message = bbcode2html($privmsg_message);
-        $preview_subject = $wordCensor->censorString($privmsg_subject);
-        $preview_message = $wordCensor->censorString($preview_message);
+        $preview_subject = censor()->censorString($privmsg_subject);
+        $preview_message = censor()->censorString($preview_message);
 
         $s_hidden_fields = '<input type="hidden" name="folder" value="' . $folder . '" />';
         $s_hidden_fields .= '<input type="hidden" name="mode" value="' . $mode . '" />';
@@ -1381,7 +1381,7 @@ if ($mode == 'read') {
 
             $msg_userid = $row['user_id'];
             $msg_user = profile_url($row);
-            $msg_subject = $wordCensor->censorString($row['privmsgs_subject']);
+            $msg_subject = censor()->censorString($row['privmsgs_subject']);
 
             $u_subject = PM_URL . "?folder=$folder&amp;mode=read&amp;" . POST_POST_URL . "=$privmsg_id";
 

--- a/search.php
+++ b/search.php
@@ -571,7 +571,7 @@ if ($post_mode) {
             'FORUM_ID' => $forum_id,
             'FORUM_NAME' => $forum_name_html[$forum_id],
             'TOPIC_ID' => $topic_id,
-            'TOPIC_TITLE' => $wordCensor->censorString($first_post['topic_title']),
+            'TOPIC_TITLE' => censor()->censorString($first_post['topic_title']),
             'TOPIC_ICON' => get_topic_icon($first_post, $is_unread_t),
         ));
 
@@ -586,7 +586,7 @@ if ($post_mode) {
             }
 
             $message = get_parsed_post($post);
-            $message = $wordCensor->censorString($message);
+            $message = censor()->censorString($message);
 
             $template->assign_block_vars('t.p', array(
                 'ROW_NUM' => $row_num,
@@ -787,7 +787,7 @@ else {
             'FORUM_NAME' => $forum_name_html[$forum_id],
             'TOPIC_ID' => $topic_id,
             'HREF_TOPIC_ID' => $moved ? $topic['topic_moved_id'] : $topic['topic_id'],
-            'TOPIC_TITLE' => $wordCensor->censorString($topic['topic_title']),
+            'TOPIC_TITLE' => censor()->censorString($topic['topic_title']),
             'IS_UNREAD' => $is_unread,
             'TOPIC_ICON' => get_topic_icon($topic, $is_unread),
             'PAGINATION' => $moved ? '' : build_topic_pagination(TOPIC_URL . $topic_id, $topic['topic_replies'], config()->get('posts_per_page')),

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -196,8 +196,8 @@ class Ajax
             ];
         }
 
-        if (Dev::sqlDebugAllowed()) {
-            $this->response['sql_log'] = Dev::getSqlLog();
+        if (dev()->checkSqlDebugAllowed()) {
+            $this->response['sql_log'] = dev()->getSqlDebugLog();
         }
 
         // sending output will be handled by $this->ob_handler()

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -68,7 +68,9 @@ class Ajax
      */
     public function exec()
     {
-        global $lang;
+        /** @noinspection PhpUnusedLocalVariableInspection */
+        // bb_cfg deprecated, but kept for compatibility with non-adapted ajax files
+        global $bb_cfg, $lang;
 
         // Exit if we already have errors
         if (!empty($this->response['error_code'])) {

--- a/src/Censor.php
+++ b/src/Censor.php
@@ -67,7 +67,7 @@ class Censor
     {
         global $datastore;
 
-        if (!config()->get('use_word_censor')) {
+        if (!$this->isEnabled()) {
             return;
         }
 
@@ -88,6 +88,10 @@ class Censor
      */
     public function censorString(string $word): string
     {
+        if (!$this->isEnabled()) {
+            return $word;
+        }
+
         return preg_replace($this->words, $this->replacements, $word);
     }
 

--- a/src/Censor.php
+++ b/src/Censor.php
@@ -10,11 +10,15 @@
 namespace TorrentPier;
 
 /**
- * Class Censor
- * @package TorrentPier
+ * Word Censoring System
+ *
+ * Singleton class that provides word censoring functionality
+ * with automatic loading of censored words from the datastore.
  */
 class Censor
 {
+    private static ?Censor $instance = null;
+
     /**
      * Word replacements
      *
@@ -32,7 +36,34 @@ class Censor
     /**
      * Initialize word censor
      */
-    public function __construct()
+    private function __construct()
+    {
+        $this->loadCensoredWords();
+    }
+
+    /**
+     * Get the singleton instance of Censor
+     */
+    public static function getInstance(): Censor
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
+     * Initialize the censor system (for compatibility)
+     */
+    public static function init(): Censor
+    {
+        return self::getInstance();
+    }
+
+    /**
+     * Load censored words from datastore
+     */
+    private function loadCensoredWords(): void
     {
         global $datastore;
 
@@ -58,5 +89,57 @@ class Censor
     public function censorString(string $word): string
     {
         return preg_replace($this->words, $this->replacements, $word);
+    }
+
+    /**
+     * Reload censored words from datastore
+     * Useful when words are updated in admin panel
+     */
+    public function reload(): void
+    {
+        $this->words = [];
+        $this->replacements = [];
+        $this->loadCensoredWords();
+    }
+
+    /**
+     * Check if censoring is enabled
+     */
+    public function isEnabled(): bool
+    {
+        return config()->get('use_word_censor', false);
+    }
+
+    /**
+     * Add a censored word (runtime only)
+     *
+     * @param string $word
+     * @param string $replacement
+     */
+    public function addWord(string $word, string $replacement): void
+    {
+        $this->words[] = '#(?<![\p{Nd}\p{L}_])(' . str_replace('\*', '[\p{Nd}\p{L}_]*?', preg_quote($word, '#')) . ')(?![\p{Nd}\p{L}_])#iu';
+        $this->replacements[] = $replacement;
+    }
+
+    /**
+     * Get all censored words count
+     */
+    public function getWordsCount(): int
+    {
+        return count($this->words);
+    }
+
+    /**
+     * Prevent cloning of the singleton instance
+     */
+    private function __clone() {}
+
+    /**
+     * Prevent unserialization of the singleton instance
+     */
+    public function __wakeup()
+    {
+        throw new \Exception("Cannot unserialize a singleton.");
     }
 }

--- a/src/Legacy/Atom.php
+++ b/src/Legacy/Atom.php
@@ -179,7 +179,7 @@ class Atom
      */
     private static function create_atom($file_path, $mode, $id, $title, $topics)
     {
-        global $lang, $wordCensor;
+        global $lang;
         $date = null;
         $time = null;
         $dir = \dirname($file_path);
@@ -213,7 +213,7 @@ class Atom
             if (isset($topic['tor_status'])) {
                 $tor_status = " ({$lang['TOR_STATUS_NAME'][$topic['tor_status']]})";
             }
-            $topic_title = $wordCensor->censorString($topic['topic_title']);
+            $topic_title = censor()->censorString($topic['topic_title']);
             $author_name = $topic['first_username'] ?: $lang['GUEST'];
             $last_time = $topic['topic_last_post_time'];
             if ($topic['topic_last_post_edit_time']) {

--- a/src/Legacy/Cache/APCu.php
+++ b/src/Legacy/Cache/APCu.php
@@ -61,7 +61,7 @@ class APCu extends Common
         }
         $this->apcu = new Apc();
         $this->prefix = $prefix;
-        $this->dbg_enabled = Dev::sqlDebugAllowed();
+        $this->dbg_enabled = dev()->checkSqlDebugAllowed();
     }
 
     /**

--- a/src/Legacy/Cache/Common.php
+++ b/src/Legacy/Cache/Common.php
@@ -82,7 +82,7 @@ class Common
         switch ($mode) {
             case 'start':
                 $this->sql_starttime = utime();
-                $dbg['sql'] = Dev::shortQuery($cur_query ?? $this->cur_query);
+                $dbg['sql'] = dev()->formatShortQuery($cur_query ?? $this->cur_query);
                 $dbg['src'] = $this->debug_find_source();
                 $dbg['file'] = $this->debug_find_source('file');
                 $dbg['line'] = $this->debug_find_source('line');

--- a/src/Legacy/Cache/File.php
+++ b/src/Legacy/Cache/File.php
@@ -61,7 +61,7 @@ class File extends Common
         $filesystem = new Filesystem($adapter);
         $this->file = new Flysystem($filesystem);
         $this->prefix = $prefix;
-        $this->dbg_enabled = Dev::sqlDebugAllowed();
+        $this->dbg_enabled = dev()->checkSqlDebugAllowed();
     }
 
     /**

--- a/src/Legacy/Cache/Memcached.php
+++ b/src/Legacy/Cache/Memcached.php
@@ -85,7 +85,7 @@ class Memcached extends Common
         $this->client = new MemcachedClient();
         $this->cfg = $cfg;
         $this->prefix = $prefix;
-        $this->dbg_enabled = Dev::sqlDebugAllowed();
+        $this->dbg_enabled = dev()->checkSqlDebugAllowed();
     }
 
     /**

--- a/src/Legacy/Cache/Redis.php
+++ b/src/Legacy/Cache/Redis.php
@@ -85,7 +85,7 @@ class Redis extends Common
         $this->client = new RedisClient();
         $this->cfg = $cfg;
         $this->prefix = $prefix;
-        $this->dbg_enabled = Dev::sqlDebugAllowed();
+        $this->dbg_enabled = dev()->checkSqlDebugAllowed();
     }
 
     /**

--- a/src/Legacy/Cache/Sqlite.php
+++ b/src/Legacy/Cache/Sqlite.php
@@ -71,7 +71,7 @@ class Sqlite extends Common
         $client = new PDO('sqlite:' . $dir . $this->dbExtension);
         $this->sqlite = new SQLiteCache($client);
         $this->prefix = $prefix;
-        $this->dbg_enabled = Dev::sqlDebugAllowed();
+        $this->dbg_enabled = dev()->checkSqlDebugAllowed();
     }
 
     /**

--- a/src/Legacy/Datastore/APCu.php
+++ b/src/Legacy/Datastore/APCu.php
@@ -54,7 +54,7 @@ class APCu extends Common
         }
         $this->apcu = new Apc();
         $this->prefix = $prefix;
-        $this->dbg_enabled = Dev::sqlDebugAllowed();
+        $this->dbg_enabled = dev()->checkSqlDebugAllowed();
     }
 
     /**

--- a/src/Legacy/Datastore/Common.php
+++ b/src/Legacy/Datastore/Common.php
@@ -157,7 +157,7 @@ class Common
         switch ($mode) {
             case 'start':
                 $this->sql_starttime = utime();
-                $dbg['sql'] = Dev::shortQuery($cur_query ?? $this->cur_query);
+                $dbg['sql'] = dev()->formatShortQuery($cur_query ?? $this->cur_query);
                 $dbg['src'] = $this->debug_find_source();
                 $dbg['file'] = $this->debug_find_source('file');
                 $dbg['line'] = $this->debug_find_source('line');

--- a/src/Legacy/Datastore/File.php
+++ b/src/Legacy/Datastore/File.php
@@ -54,7 +54,7 @@ class File extends Common
         $filesystem = new Filesystem($adapter);
         $this->file = new Flysystem($filesystem);
         $this->prefix = $prefix;
-        $this->dbg_enabled = Dev::sqlDebugAllowed();
+        $this->dbg_enabled = dev()->checkSqlDebugAllowed();
     }
 
     /**

--- a/src/Legacy/Datastore/Memcached.php
+++ b/src/Legacy/Datastore/Memcached.php
@@ -78,7 +78,7 @@ class Memcached extends Common
         $this->client = new MemcachedClient();
         $this->cfg = $cfg;
         $this->prefix = $prefix;
-        $this->dbg_enabled = Dev::sqlDebugAllowed();
+        $this->dbg_enabled = dev()->checkSqlDebugAllowed();
     }
 
     /**

--- a/src/Legacy/Datastore/Redis.php
+++ b/src/Legacy/Datastore/Redis.php
@@ -78,7 +78,7 @@ class Redis extends Common
         $this->client = new RedisClient();
         $this->cfg = $cfg;
         $this->prefix = $prefix;
-        $this->dbg_enabled = Dev::sqlDebugAllowed();
+        $this->dbg_enabled = dev()->checkSqlDebugAllowed();
     }
 
     /**

--- a/src/Legacy/Datastore/Sqlite.php
+++ b/src/Legacy/Datastore/Sqlite.php
@@ -64,7 +64,7 @@ class Sqlite extends Common
         $client = new PDO('sqlite:' . $dir . $this->dbExtension);
         $this->sqlite = new SQLiteCache($client);
         $this->prefix = $prefix;
-        $this->dbg_enabled = Dev::sqlDebugAllowed();
+        $this->dbg_enabled = dev()->checkSqlDebugAllowed();
     }
 
     /**

--- a/src/Legacy/Post.php
+++ b/src/Legacy/Post.php
@@ -341,7 +341,7 @@ class Post
      */
     public static function user_notification($mode, &$post_data, &$topic_title, &$forum_id, &$topic_id, &$notify_user)
     {
-        global $lang, $userdata, $wordCensor;
+        global $lang, $userdata;
 
         if (!config()->get('topic_notify_enabled')) {
             return;
@@ -363,7 +363,7 @@ class Post
 			");
 
                 if ($watch_list) {
-                    $topic_title = $wordCensor->censorString($topic_title);
+                    $topic_title = censor()->censorString($topic_title);
 
                     $u_topic = make_url(TOPIC_URL . $topic_id . '&view=newest#newest');
                     $unwatch_topic = make_url(TOPIC_URL . "$topic_id&unwatch=topic");

--- a/src/Legacy/SqlDb.php
+++ b/src/Legacy/SqlDb.php
@@ -60,7 +60,7 @@ class SqlDb
         global $DBS;
 
         $this->cfg = array_combine($this->cfg_keys, $cfg_values);
-        $this->dbg_enabled = (Dev::sqlDebugAllowed() || !empty($_COOKIE['explain']));
+        $this->dbg_enabled = (dev()->checkSqlDebugAllowed() || !empty($_COOKIE['explain']));
         $this->do_explain = ($this->dbg_enabled && !empty($_COOKIE['explain']));
         $this->slow_time = SQL_SLOW_QUERY_TIME;
 
@@ -839,7 +839,7 @@ class SqlDb
         $msg[] = sprintf('%-6s', $q_time);
         $msg[] = sprintf('%05d', getmypid());
         $msg[] = $this->db_server;
-        $msg[] = Dev::shortQuery($this->cur_query);
+        $msg[] = dev()->formatShortQuery($this->cur_query);
         $msg = implode(LOG_SEPR, $msg);
         $msg .= ($info = $this->query_info()) ? ' # ' . $info : '';
         $msg .= ' # ' . $this->debug_find_source() . ' ';
@@ -948,7 +948,7 @@ class SqlDb
 				</tr>
 				<tr><td colspan="2">' . $this->explain_hold . '</td></tr>
 				</table>
-				<div class="sqlLog"><div id="' . $htid . '" class="sqlLogRow sqlExplain" style="padding: 0;">' . Dev::shortQuery($dbg['sql'], true) . '&nbsp;&nbsp;</div></div>
+				            <div class="sqlLog"><div id="' . $htid . '" class="sqlLogRow sqlExplain" style="padding: 0;">' . dev()->formatShortQuery($dbg['sql'], true) . '&nbsp;&nbsp;</div></div>
 				<br />';
                 break;
 

--- a/viewforum.php
+++ b/viewforum.php
@@ -445,7 +445,7 @@ foreach ($topic_rowset as $topic) {
         'FORUM_ID' => $forum_id,
         'TOPIC_ID' => $topic_id,
         'HREF_TOPIC_ID' => $moved ? $topic['topic_moved_id'] : $topic['topic_id'],
-        'TOPIC_TITLE' => $wordCensor->censorString($topic['topic_title']),
+        'TOPIC_TITLE' => censor()->censorString($topic['topic_title']),
         'TOPICS_SEPARATOR' => $separator,
         'IS_UNREAD' => $is_unread,
         'TOPIC_ICON' => get_topic_icon($topic, $is_unread),

--- a/viewtopic.php
+++ b/viewtopic.php
@@ -364,7 +364,7 @@ if (!$ranks = $datastore->get('ranks')) {
 }
 
 // Censor topic title
-$topic_title = $wordCensor->censorString($topic_title);
+$topic_title = censor()->censorString($topic_title);
 
 // Post, reply and other URL generation for templating vars
 $new_topic_url = POSTING_URL . "?mode=newtopic&amp;" . POST_FORUM_URL . "=$forum_id";
@@ -624,8 +624,8 @@ for ($i = 0; $i < $total_posts; $i++) {
         $user_sig = str_replace(
             '\"', '"',
             substr(
-                preg_replace_callback('#(\>(((?>([^><]+|(?R)))*)\<))#s', function ($matches) use ($wordCensor) {
-                    return $wordCensor->censorString(reset($matches));
+                preg_replace_callback('#(\>(((?>([^><]+|(?R)))*)\<))#s', function ($matches) {
+                    return censor()->censorString(reset($matches));
                 }, '>' . $user_sig . '<'), 1, -1
             )
         );
@@ -634,8 +634,8 @@ for ($i = 0; $i < $total_posts; $i++) {
     $message = str_replace(
         '\"', '"',
         substr(
-            preg_replace_callback('#(\>(((?>([^><]+|(?R)))*)\<))#s', function ($matches) use ($wordCensor) {
-                return $wordCensor->censorString(reset($matches));
+            preg_replace_callback('#(\>(((?>([^><]+|(?R)))*)\<))#s', function ($matches) {
+                return censor()->censorString(reset($matches));
             }, '>' . $message . '<'), 1, -1
         )
     );


### PR DESCRIPTION
- Convert TorrentPier\Censor to singleton pattern following Config class design
- Add global censor() helper function for consistent API access
- Replace all global $wordCensor declarations and usage across 12 files
- Implement automatic reload functionality in admin panel
- Add enhanced methods: isEnabled(), addWord(), getWordsCount(), reload()

Files updated:
- src/Legacy/Atom.php, src/Legacy/Post.php
- viewforum.php, posting.php, search.php, index.php, viewtopic.php, privmsg.php
- library/ajax/posts.php, library/includes/bbcode.php, library/includes/ucp/topic_watch.php
- admin/admin_words.php, library/includes/init_bb.php
- common.php (added global helper)
- UPGRADE_GUIDE.md (documentation)

Benefits:
- Single instance shared across application for better performance
- Memory efficient word loading only when censoring enabled
- Consistent API pattern matching config() singleton
- Automatic word reloading when admin updates censored words
- Enhanced developer experience with new utility methods

BREAKING CHANGE: None - full backward compatibility maintained. The global $wordCensor variable continues to work as before. New censor() function is the recommended approach going forward.