### PR TITLE
refactor(dev): convert Dev class to singleton pattern

### DIFF
--- a/common.php
+++ b/common.php
@@ -111,6 +111,16 @@ function censor(): \TorrentPier\Censor
 }
 
 /**
+ * Get the Dev instance
+ *
+ * @return \TorrentPier\Dev
+ */
+function dev(): \TorrentPier\Dev
+{
+    return \TorrentPier\Dev::getInstance();
+}
+
+/**
  * Initialize debug
  */
 define('APP_ENV', env('APP_ENV', 'production'));
@@ -119,7 +129,6 @@ if (APP_ENV === 'local') {
 } else {
     define('DBG_USER', isset($_COOKIE[COOKIE_DBG]));
 }
-(new \TorrentPier\Dev());
 
 /**
  * Server variables initialize

--- a/library/includes/page_footer_dev.php
+++ b/library/includes/page_footer_dev.php
@@ -71,7 +71,7 @@ if (!empty($_COOKIE['explain'])) {
     }
 }
 
-$sql_log = !empty($_COOKIE['sql_log']) ? \TorrentPier\Dev::getSqlLog() : false;
+$sql_log = !empty($_COOKIE['sql_log']) ? dev()->getSqlDebugLog() : false;
 
 if ($sql_log) {
     echo '<div class="sqlLog" id="sqlLog">' . $sql_log . '</div><!-- / sqlLog --><br clear="all" />';

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -196,8 +196,8 @@ class Ajax
             ];
         }
 
-        if (Dev::sqlDebugAllowed()) {
-            $this->response['sql_log'] = Dev::getSqlLog();
+        if (dev()->checkSqlDebugAllowed()) {
+            $this->response['sql_log'] = dev()->getSqlDebugLog();
         }
 
         // sending output will be handled by $this->ob_handler()

--- a/src/Legacy/Cache/APCu.php
+++ b/src/Legacy/Cache/APCu.php
@@ -61,7 +61,7 @@ class APCu extends Common
         }
         $this->apcu = new Apc();
         $this->prefix = $prefix;
-        $this->dbg_enabled = Dev::sqlDebugAllowed();
+        $this->dbg_enabled = dev()->checkSqlDebugAllowed();
     }
 
     /**

--- a/src/Legacy/Cache/Common.php
+++ b/src/Legacy/Cache/Common.php
@@ -82,7 +82,7 @@ class Common
         switch ($mode) {
             case 'start':
                 $this->sql_starttime = utime();
-                $dbg['sql'] = Dev::shortQuery($cur_query ?? $this->cur_query);
+                $dbg['sql'] = dev()->formatShortQuery($cur_query ?? $this->cur_query);
                 $dbg['src'] = $this->debug_find_source();
                 $dbg['file'] = $this->debug_find_source('file');
                 $dbg['line'] = $this->debug_find_source('line');

--- a/src/Legacy/Cache/File.php
+++ b/src/Legacy/Cache/File.php
@@ -61,7 +61,7 @@ class File extends Common
         $filesystem = new Filesystem($adapter);
         $this->file = new Flysystem($filesystem);
         $this->prefix = $prefix;
-        $this->dbg_enabled = Dev::sqlDebugAllowed();
+        $this->dbg_enabled = dev()->checkSqlDebugAllowed();
     }
 
     /**

--- a/src/Legacy/Cache/Memcached.php
+++ b/src/Legacy/Cache/Memcached.php
@@ -85,7 +85,7 @@ class Memcached extends Common
         $this->client = new MemcachedClient();
         $this->cfg = $cfg;
         $this->prefix = $prefix;
-        $this->dbg_enabled = Dev::sqlDebugAllowed();
+        $this->dbg_enabled = dev()->checkSqlDebugAllowed();
     }
 
     /**

--- a/src/Legacy/Cache/Redis.php
+++ b/src/Legacy/Cache/Redis.php
@@ -85,7 +85,7 @@ class Redis extends Common
         $this->client = new RedisClient();
         $this->cfg = $cfg;
         $this->prefix = $prefix;
-        $this->dbg_enabled = Dev::sqlDebugAllowed();
+        $this->dbg_enabled = dev()->checkSqlDebugAllowed();
     }
 
     /**

--- a/src/Legacy/Cache/Sqlite.php
+++ b/src/Legacy/Cache/Sqlite.php
@@ -71,7 +71,7 @@ class Sqlite extends Common
         $client = new PDO('sqlite:' . $dir . $this->dbExtension);
         $this->sqlite = new SQLiteCache($client);
         $this->prefix = $prefix;
-        $this->dbg_enabled = Dev::sqlDebugAllowed();
+        $this->dbg_enabled = dev()->checkSqlDebugAllowed();
     }
 
     /**

--- a/src/Legacy/Datastore/APCu.php
+++ b/src/Legacy/Datastore/APCu.php
@@ -54,7 +54,7 @@ class APCu extends Common
         }
         $this->apcu = new Apc();
         $this->prefix = $prefix;
-        $this->dbg_enabled = Dev::sqlDebugAllowed();
+        $this->dbg_enabled = dev()->checkSqlDebugAllowed();
     }
 
     /**

--- a/src/Legacy/Datastore/Common.php
+++ b/src/Legacy/Datastore/Common.php
@@ -157,7 +157,7 @@ class Common
         switch ($mode) {
             case 'start':
                 $this->sql_starttime = utime();
-                $dbg['sql'] = Dev::shortQuery($cur_query ?? $this->cur_query);
+                $dbg['sql'] = dev()->formatShortQuery($cur_query ?? $this->cur_query);
                 $dbg['src'] = $this->debug_find_source();
                 $dbg['file'] = $this->debug_find_source('file');
                 $dbg['line'] = $this->debug_find_source('line');

--- a/src/Legacy/Datastore/File.php
+++ b/src/Legacy/Datastore/File.php
@@ -54,7 +54,7 @@ class File extends Common
         $filesystem = new Filesystem($adapter);
         $this->file = new Flysystem($filesystem);
         $this->prefix = $prefix;
-        $this->dbg_enabled = Dev::sqlDebugAllowed();
+        $this->dbg_enabled = dev()->checkSqlDebugAllowed();
     }
 
     /**

--- a/src/Legacy/Datastore/Memcached.php
+++ b/src/Legacy/Datastore/Memcached.php
@@ -78,7 +78,7 @@ class Memcached extends Common
         $this->client = new MemcachedClient();
         $this->cfg = $cfg;
         $this->prefix = $prefix;
-        $this->dbg_enabled = Dev::sqlDebugAllowed();
+        $this->dbg_enabled = dev()->checkSqlDebugAllowed();
     }
 
     /**

--- a/src/Legacy/Datastore/Redis.php
+++ b/src/Legacy/Datastore/Redis.php
@@ -78,7 +78,7 @@ class Redis extends Common
         $this->client = new RedisClient();
         $this->cfg = $cfg;
         $this->prefix = $prefix;
-        $this->dbg_enabled = Dev::sqlDebugAllowed();
+        $this->dbg_enabled = dev()->checkSqlDebugAllowed();
     }
 
     /**

--- a/src/Legacy/Datastore/Sqlite.php
+++ b/src/Legacy/Datastore/Sqlite.php
@@ -64,7 +64,7 @@ class Sqlite extends Common
         $client = new PDO('sqlite:' . $dir . $this->dbExtension);
         $this->sqlite = new SQLiteCache($client);
         $this->prefix = $prefix;
-        $this->dbg_enabled = Dev::sqlDebugAllowed();
+        $this->dbg_enabled = dev()->checkSqlDebugAllowed();
     }
 
     /**

--- a/src/Legacy/SqlDb.php
+++ b/src/Legacy/SqlDb.php
@@ -60,7 +60,7 @@ class SqlDb
         global $DBS;
 
         $this->cfg = array_combine($this->cfg_keys, $cfg_values);
-        $this->dbg_enabled = (Dev::sqlDebugAllowed() || !empty($_COOKIE['explain']));
+        $this->dbg_enabled = (dev()->checkSqlDebugAllowed() || !empty($_COOKIE['explain']));
         $this->do_explain = ($this->dbg_enabled && !empty($_COOKIE['explain']));
         $this->slow_time = SQL_SLOW_QUERY_TIME;
 
@@ -839,7 +839,7 @@ class SqlDb
         $msg[] = sprintf('%-6s', $q_time);
         $msg[] = sprintf('%05d', getmypid());
         $msg[] = $this->db_server;
-        $msg[] = Dev::shortQuery($this->cur_query);
+        $msg[] = dev()->formatShortQuery($this->cur_query);
         $msg = implode(LOG_SEPR, $msg);
         $msg .= ($info = $this->query_info()) ? ' # ' . $info : '';
         $msg .= ' # ' . $this->debug_find_source() . ' ';
@@ -948,7 +948,7 @@ class SqlDb
 				</tr>
 				<tr><td colspan="2">' . $this->explain_hold . '</td></tr>
 				</table>
-				<div class="sqlLog"><div id="' . $htid . '" class="sqlLogRow sqlExplain" style="padding: 0;">' . Dev::shortQuery($dbg['sql'], true) . '&nbsp;&nbsp;</div></div>
+				            <div class="sqlLog"><div id="' . $htid . '" class="sqlLogRow sqlExplain" style="padding: 0;">' . dev()->formatShortQuery($dbg['sql'], true) . '&nbsp;&nbsp;</div></div>
 				<br />';
                 break;
 


### PR DESCRIPTION
- Convert TorrentPier\Dev class from direct instantiation to singleton pattern
- Add getInstance() method and private constructor for singleton implementation
- Introduce new instance methods with improved naming:
  * getSqlDebugLog() (replaces getSqlLog())
  * checkSqlDebugAllowed() (replaces sqlDebugAllowed())
  * formatShortQuery() (replaces shortQuery())
- Add dev() global helper function for consistent access pattern
- Maintain full backward compatibility with existing static method calls
- Update all internal usage across 18 files to use new singleton pattern:
  * src/Ajax.php, src/Legacy/SqlDb.php
  * All Cache classes (APCu, File, Memcached, Redis, Sqlite, Common)
  * All Datastore classes (APCu, File, Memcached, Redis, Sqlite, Common)
  * library/includes/page_footer_dev.php
- Implement lazy initialization consistent with Config and Censor singletons
- Add comprehensive migration guide in UPGRADE_GUIDE.md

This refactoring improves resource management, provides consistent API patterns across all singleton classes, and maintains zero breaking changes for existing code.