### PR TITLE
fix(User): add null and array checks before session data operations

### DIFF
--- a/src/Legacy/Common/User.php
+++ b/src/Legacy/Common/User.php
@@ -151,7 +151,9 @@ class User
                     $update_sessions_table = true;
                 }
 
-                Sessions::cache_set_userdata($this->data);
+                if ($this->data) {
+                    Sessions::cache_set_userdata($this->data);
+                }
             }
         }
 
@@ -335,11 +337,13 @@ class User
      */
     public function session_end(bool $update_lastvisit = false, bool $set_cookie = true)
     {
-        Sessions::cache_rm_userdata($this->data);
-        DB()->query("
-			DELETE FROM " . BB_SESSIONS . "
-			WHERE session_id = '{$this->data['session_id']}'
-		");
+        if ($this->data && is_array($this->data)) {
+            Sessions::cache_rm_userdata($this->data);
+            DB()->query("
+                DELETE FROM " . BB_SESSIONS . "
+                WHERE session_id = '{$this->data['session_id']}'
+            ");
+        }
 
         if (!IS_GUEST) {
             if ($update_lastvisit) {


### PR DESCRIPTION
Ensure that session data is only processed if it exists and is an array. This prevents potential errors when attempting to cache or remove user session data. Updated methods `cache_set_userdata` and `cache_rm_userdata` to include necessary checks.