### PR TITLE
feat(database): add visual markers for Nette Explorer queries in debug panel

### DIFF
--- a/src/Database/DebugSelection.php
+++ b/src/Database/DebugSelection.php
@@ -78,6 +78,9 @@ class DebugSelection
         // Use the actual SQL with substituted parameters for both logging and EXPLAIN
         $sql = $this->generateSqlForLogging($method, $arguments, false);
 
+        // Mark this query as coming from Nette Explorer
+        $this->db->debugger->markAsNetteExplorerQuery();
+
         // Set the query for debug logging
         $this->db->cur_query = $sql;
         $this->db->debug('start');

--- a/src/Dev.php
+++ b/src/Dev.php
@@ -258,9 +258,11 @@ class Dev
             $sql = $this->shortQueryInstance($dbg['sql'], true);
             $time = sprintf('%.3f', $dbg['time']);
             $perc = '[' . round($dbg['time'] * 100 / $db_obj->sql_timetotal) . '%]';
+            // Use plain text version for title attribute to avoid HTML issues
+            $info_plain = !empty($dbg['info_plain']) ? $dbg['info_plain'] . ' [' . $dbg['src'] . ']' : $dbg['src'];
             $info = !empty($dbg['info']) ? $dbg['info'] . ' [' . $dbg['src'] . ']' : $dbg['src'];
 
-            $log .= '<div onclick="$(this).toggleClass(\'sqlHighlight\');" class="sqlLogRow" title="' . $info . '">'
+            $log .= '<div onclick="$(this).toggleClass(\'sqlHighlight\');" class="sqlLogRow" title="' . htmlspecialchars($info_plain) . '">'
                 . '<span style="letter-spacing: -1px;">' . $time . ' </span>'
                 . '<span class="copyElement" data-clipboard-target="#' . $id . '" title="Copy to clipboard" style="color: rgb(128,128,128); letter-spacing: -1px;">' . $perc . '</span>&nbsp;'
                 . '<span style="letter-spacing: 0;" id="' . $id . '">' . $sql . '</span>'


### PR DESCRIPTION
Add automatic detection and colorful badges to distinguish Nette Explorer queries from legacy database calls, helping track modernization progress.

- Detect Nette SQL patterns (backticks, parentheses)
- Add green styled [Nette Explorer] badges
- Fix HTML escaping in debug tooltips
- Prevent marker duplication