### PR TITLE
removed: Useless password max length restriction

### DIFF
--- a/library/includes/init_bb.php
+++ b/library/includes/init_bb.php
@@ -265,7 +265,6 @@ define('USERNAME_MIN_LENGTH', 3);
 define('USERNAME_MAX_LENGTH', 30);
 define('USEREMAIL_MAX_LENGTH', 230);
 define('PASSWORD_MIN_LENGTH', 8);
-define('PASSWORD_MAX_LENGTH', 128);
 
 define('PAGE_HEADER', INC_DIR . '/page_header.php');
 define('PAGE_FOOTER', INC_DIR . '/page_footer.php');

--- a/library/includes/ucp/register.php
+++ b/library/includes/ucp/register.php
@@ -723,7 +723,7 @@ $template->assign_vars([
     'EDIT_PROFILE' => ($mode == 'editprofile'),
     'ADM_EDIT' => $adm_edit,
     'SHOW_PASS' => ($adm_edit || ($mode == 'register' && IS_ADMIN)),
-    'PASSWORD_LONG' => sprintf($lang['PASSWORD_LONG'], PASSWORD_MAX_LENGTH, PASSWORD_MIN_LENGTH),
+    'PASSWORD_LONG' => sprintf($lang['PASSWORD_LONG'], PASSWORD_MIN_LENGTH),
     'INVITE_CODE' => !empty($_GET['invite']) ? htmlCHR($_GET['invite']) : '',
     'CAPTCHA_HTML' => ($need_captcha) ? bb_captcha('get') : '',
 

--- a/library/language/en/main.php
+++ b/library/language/en/main.php
@@ -623,7 +623,7 @@ $lang['PROFILE_UPDATED_INACTIVE'] = 'Your profile has been updated. However, you
 
 $lang['PASSWORD_MISMATCH'] = 'The passwords you entered did not match.';
 $lang['CURRENT_PASSWORD_MISMATCH'] = 'The current password you supplied does not match that stored in the database.';
-$lang['PASSWORD_LONG'] = 'Your password must be no longer than %d characters and no shorter than %d characters.';
+$lang['PASSWORD_LONG'] = 'Your password must be no shorter than %d characters.';
 $lang['TOO_MANY_REGISTERS'] = 'You have made too many registration attempts. Please try again later.';
 $lang['USERNAME_TAKEN'] = 'Sorry, but this username has already been taken.';
 $lang['USERNAME_INVALID'] = 'Sorry, but this username contains an invalid character';
@@ -1787,7 +1787,6 @@ $lang['CHOOSE_E_MAIL'] = 'You must specify the e-mail';
 $lang['CHOOSE_PASS'] = 'Field for the password must not be empty!';
 $lang['CHOOSE_PASS_ERR'] = 'Entered passwords do not match';
 $lang['CHOOSE_PASS_ERR_MIN'] = 'Your password must be at least %d characters';
-$lang['CHOOSE_PASS_ERR_MAX'] = 'Your password must be no longer than $d characters';
 $lang['CHOOSE_PASS_ERR_NUM'] = 'The password must contain at least one digit';
 $lang['CHOOSE_PASS_ERR_LETTER'] = 'The password must contain at least one letter of the Latin alphabet';
 $lang['CHOOSE_PASS_ERR_LETTER_UPPERCASE'] = 'The password must contain at least one uppercase letter of the Latin alphabet';

--- a/src/Validate.php
+++ b/src/Validate.php
@@ -170,9 +170,6 @@ class Validate
         }
 
         // Length
-        if (mb_strlen($password, DEFAULT_CHARSET) > PASSWORD_MAX_LENGTH) {
-            return sprintf($lang['CHOOSE_PASS_ERR_MAX'], PASSWORD_MAX_LENGTH);
-        }
         if (mb_strlen($password, DEFAULT_CHARSET) < PASSWORD_MIN_LENGTH) {
             return sprintf($lang['CHOOSE_PASS_ERR_MIN'], PASSWORD_MIN_LENGTH);
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed the maximum password length restriction during registration and validation.
	- Updated password requirement messages to reflect only the minimum length requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->