### PR TITLE
fix(template): handle L_ variables in template vars when not found in lang vars

### DIFF
--- a/src/Legacy/Template.php
+++ b/src/Legacy/Template.php
@@ -767,7 +767,7 @@ class Template
         }
         // This will handle the remaining root-level varrefs
         // Handle L_ language variables specifically - show plain text when not found
-        $code = preg_replace('#\{(L_([a-z0-9\-_]+?))\}#i', '<?php echo isset($L[\'$2\']) ? $L[\'$2\'] : \'$1\'; ?>', $code);
+        $code = preg_replace('#\{(L_([a-z0-9\-_]+?))\}#i', '<?php echo isset($L[\'$2\']) ? $L[\'$2\'] : (isset($V[\'$1\']) ? $V[\'$1\'] : \'$1\'); ?>', $code);
         // Handle PHP variables
         $code = preg_replace('#\{(\$[a-z_][a-z0-9_$\->\'\"\.\[\]]*?)\}#i', '<?php echo isset($1) ? $1 : \'\'; ?>', $code);
         // Handle constants


### PR DESCRIPTION
Template variables starting with L_ (like L_MY_PROFILE) are now properly resolved when they exist in template variables but not in language variables. Previously, these would fall back to showing the literal variable name.

The L_ variable regex now checks both $L (language) and $V (template) arrays before falling back to the literal string, maintaining backward compatibility while fixing composite language variables set via template assignment.