### PR TITLE
chore: update nunomaduro/collision to version 8.8.2 and add BrowserStack sponsorship information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ TorrentPier is currently being **completely rewritten from scratch on Laravel**.
 
 We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/torrentpier/torrentpier/tags).
 
+## 🤝 Sponsors
+
+This project is tested with BrowserStack.
+
 ## 📖 License
 
 This project is licensed under the MIT License - see the [LICENSE](https://github.com/torrentpier/torrentpier/blob/master/LICENSE) file for details.

--- a/composer.lock
+++ b/composer.lock
@@ -6845,16 +6845,16 @@
         },
         {
             "name": "nunomaduro/collision",
-            "version": "v8.8.1",
+            "version": "v8.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/collision.git",
-                "reference": "44ccb82e3e21efb5446748d2a3c81a030ac22bd5"
+                "reference": "60207965f9b7b7a4ce15a0f75d57f9dadb105bdb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/44ccb82e3e21efb5446748d2a3c81a030ac22bd5",
-                "reference": "44ccb82e3e21efb5446748d2a3c81a030ac22bd5",
+                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/60207965f9b7b7a4ce15a0f75d57f9dadb105bdb",
+                "reference": "60207965f9b7b7a4ce15a0f75d57f9dadb105bdb",
                 "shasum": ""
             },
             "require": {
@@ -6940,7 +6940,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2025-06-11T01:04:21+00:00"
+            "time": "2025-06-25T02:12:12+00:00"
         },
         {
             "name": "pestphp/pest",


### PR DESCRIPTION
This commit updates the nunomaduro/collision dependency to version 8.8.2 to ensure compatibility with the latest improvements and bug fixes.

Additionally, sponsorship details for BrowserStack have been added to the README.md to acknowledge their support for cross-browser testing infrastructure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a "Sponsors" section to the README highlighting BrowserStack testing support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->