### PR TITLE
Update logging and mail configurations; add export-ignore for GitHub files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@
 *.md diff=markdown
 *.php diff=php
 
+/.github export-ignore
 CHANGELOG.md export-ignore
 LICENSE export-ignore
 README.md export-ignore

--- a/config/logging.php
+++ b/config/logging.php
@@ -98,10 +98,10 @@ return [
             'driver' => 'monolog',
             'level' => env('LOG_LEVEL', 'debug'),
             'handler' => StreamHandler::class,
-            'formatter' => env('LOG_STDERR_FORMATTER'),
-            'with' => [
+            'handler_with' => [
                 'stream' => 'php://stderr',
             ],
+            'formatter' => env('LOG_STDERR_FORMATTER'),
             'processors' => [PsrLogMessageProcessor::class],
         ],
 

--- a/config/mail.php
+++ b/config/mail.php
@@ -85,6 +85,7 @@ return [
                 'smtp',
                 'log',
             ],
+            'retry_after' => 60,
         ],
 
         'roundrobin' => [
@@ -93,6 +94,7 @@ return [
                 'ses',
                 'postmark',
             ],
+            'retry_after' => 60,
         ],
 
     ],


### PR DESCRIPTION
- Modified logging.php to adjust the handler_with configuration and reposition the formatter setting for clarity.
- Updated mail.php to include a 'retry_after' setting for both SMTP and roundrobin mail configurations, enhancing mail delivery reliability.
- Added export-ignore for the .github directory in .gitattributes to exclude it from package exports.