### PR TITLE
feat: Add option to use original torrent filenames for downloads

### DIFF
--- a/library/attach_mod/displaying_torrent.php
+++ b/library/attach_mod/displaying_torrent.php
@@ -66,6 +66,7 @@ $tracker_status = $attachments['_' . $post_id][$i]['tracker_status'];
 $download_count = declension((int)$attachments['_' . $post_id][$i]['download_count'], 'times');
 $tor_file_size = humn_size($attachments['_' . $post_id][$i]['filesize']);
 $tor_file_time = bb_date($attachments['_' . $post_id][$i]['filetime']);
+$real_filename = clean_filename(basename($attachments['_' . $post_id][$i]['real_filename']));
 
 $tor_reged = (bool)$tracker_status;
 $show_peers = (bool)$bb_cfg['bt_show_peers'];
@@ -88,10 +89,14 @@ if ($tor_auth_reg || $tor_auth_del) {
     $tracker_link = ($tor_reged) ? $unreg_tor_url : $reg_tor_url;
 }
 
-if ($bb_cfg['tracker']['use_old_torrent_name_format']) {
-    $display_name = '[' . $bb_cfg['server_name'] . '].t' . $bt_topic_id . '.' . TORRENT_EXT;
+if ($bb_cfg['tracker']['use_real_filename']) {
+    $display_name = $real_filename;
 } else {
-    $display_name = $t_data['topic_title'] . ' [' . $bb_cfg['server_name'] . '-' . $bt_topic_id . ']' . '.' . TORRENT_EXT;
+    if ($bb_cfg['tracker']['use_old_torrent_name_format']) {
+        $display_name = '[' . $bb_cfg['server_name'] . '].t' . $bt_topic_id . '.' . TORRENT_EXT;
+    } else {
+        $display_name = $t_data['topic_title'] . ' [' . $bb_cfg['server_name'] . '-' . $bt_topic_id . ']' . '.' . TORRENT_EXT;
+    }
 }
 
 if (!$tor_reged) {

--- a/library/config.php
+++ b/library/config.php
@@ -747,7 +747,8 @@ $bb_cfg['tracker'] = [
     'hybrid_stat_protocol' => 1, // For hybrid torrents there are two identical requests sent by clients, for counting stats we gotta choose one, you can change this to '2' in future, when v1 protocol is outdated
     'disabled_v1_torrents' => false, // disallow registration of v1-only torrents, for future implementations where client will use v2 only and there won't be need for v1, thus relieving tracker
     'disabled_v2_torrents' => false, // disallow registration of v2-only torrents
-    'use_old_torrent_name_format' => false, // when enabled, the names of torrent files will have the classic format: [yoursite.com].txxx.torrent
+    'use_real_filename' => false, // Use original torrent filename for downloads. If disabled, filename will be generated automatically
+    'use_old_torrent_name_format' => false, // Use classic filename format '[yoursite.com].txxx.torrent'. Only works when use_real_filename is disabled
 ];
 
 // Ratio settings

--- a/src/Legacy/Torrent.php
+++ b/src/Legacy/Torrent.php
@@ -644,10 +644,15 @@ class Torrent
         // Send torrent
         $output = Bencode::encode($tor);
 
-        if ($bb_cfg['tracker']['use_old_torrent_name_format']) {
-            $dl_fname = '[' . $bb_cfg['server_name'] . '].t' . $topic_id . '.' . TORRENT_EXT;
+        $real_filename = clean_filename(basename($attachment['real_filename']));
+        if ($bb_cfg['tracker']['use_real_filename']) {
+            $dl_fname = $real_filename;
         } else {
-            $dl_fname = html_ent_decode($topic_title) . ' [' . $bb_cfg['server_name'] . '-' . $topic_id . ']' . '.' . TORRENT_EXT;
+            if ($bb_cfg['tracker']['use_old_torrent_name_format']) {
+                $dl_fname = '[' . $bb_cfg['server_name'] . '].t' . $topic_id . '.' . TORRENT_EXT;
+            } else {
+                $dl_fname = html_ent_decode($topic_title) . ' [' . $bb_cfg['server_name'] . '-' . $topic_id . ']' . '.' . TORRENT_EXT;
+            }
         }
 
         if (!empty($_COOKIE['explain'])) {


### PR DESCRIPTION
This PR adds a new configuration option `use_real_filename` that allows using the original uploaded torrent filename when downloading, instead of auto-generating names.

## Changes
- Added `use_real_filename` config option (default: false)
- Modified download logic to respect the new setting
- Updated filename generation priority:
  1. Original filename (if `use_real_filename` is enabled)
  2. Classic format `[site.com].t123.torrent` (if `use_old_torrent_name_format` is enabled)
  3. Extended format `"Torrent Name [site.com-123].torrent"` (default)

## Benefits
- Preserves original filenames for better file organization
- Maintains backward compatibility with existing naming schemes
- Gives administrators more control over download filename behavior

## Configuration
```php
'use_real_filename' => false, // Use original torrent filename for downloads