### PR TITLE
fix: Make `Ajax::$action` property nullable to handle missing POST parameter

### DIFF
--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -50,7 +50,7 @@ class Ajax
         'index_data' => ['guest'],
     ];
 
-    public string $action;
+    public ?string $action;
 
     /**
      * Constructor


### PR DESCRIPTION
## Problem
When calling ajax.php without passing the 'action' parameter, PHP throws a TypeError: `Cannot assign null to property TorrentPier\Ajax::$action of type string`

## Solution
Changed the `$action` property type from `string` to `?string` to allow null values when the POST parameter is not provided.

## Changes
- Changed `public string $action;` to `public ?string $action;`