### PR TITLE
fix(docker): move database migrations from build to runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,5 @@ COPY . /app/public
 RUN php _cleanup.php && rm _cleanup.php
 RUN composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader && chmod +x ./install/docker/docker-entrypoint.sh && \
     cp ./install/docker/php.ini /usr/local/etc/php/php.ini
-RUN php vendor/bin/phinx migrate --configuration=phinx.php
 
 ENTRYPOINT "/app/public/install/docker/docker-entrypoint.sh"

--- a/install/docker/docker-entrypoint.sh
+++ b/install/docker/docker-entrypoint.sh
@@ -1,5 +1,48 @@
 #!/bin/sh
 
+# Wait for MariaDB to be ready
+echo "Waiting for MariaDB to be ready..."
+until php -r "
+\$maxAttempts = 30;
+\$attempt = 0;
+\$host = getenv('DB_HOST') ?: 'database';
+\$port = getenv('DB_PORT') ?: 3306;
+\$user = getenv('DB_USERNAME');
+\$pass = getenv('DB_PASSWORD');
+\$db = getenv('DB_DATABASE');
+
+while (\$attempt < \$maxAttempts) {
+    try {
+        \$conn = new PDO(\"mysql:host=\$host;port=\$port\", \$user, \$pass);
+        echo \"Database connection successful!\n\";
+        exit(0);
+    } catch (PDOException \$e) {
+        \$attempt++;
+        echo \"Attempt \$attempt/\$maxAttempts: Waiting for database...\n\";
+        sleep(2);
+    }
+}
+echo \"Failed to connect to database after \$maxAttempts attempts\n\";
+exit(1);
+"; do
+  echo "Database is not ready yet. Retrying..."
+  sleep 2
+done
+
+echo "Database is ready!"
+
+# Run migrations
+echo "Running database migrations..."
+cd /app/public
+php vendor/bin/phinx migrate --configuration=phinx.php
+
+if [ $? -eq 0 ]; then
+    echo "Migrations completed successfully!"
+else
+    echo "Migration failed!"
+    exit 1
+fi
+
 # Cron
 crond -f -l 2 &
 

--- a/library/includes/bbcode.php
+++ b/library/includes/bbcode.php
@@ -208,7 +208,7 @@ function generate_smilies($mode)
  */
 function strip_quotes($text)
 {
-    $lowertext = strtolower($text);
+    $lowertext = mb_strtolower($text, DEFAULT_CHARSET);
 
     // find all [quote tags
     $start_pos = [];
@@ -345,7 +345,7 @@ function extract_search_words($text)
     $min_word_len = max(2, config()->get('search_min_word_len') - 1);
     $max_word_len = config()->get('search_max_word_len');
 
-    $text = ' ' . str_compact(strip_tags(mb_strtolower($text))) . ' ';
+    $text = ' ' . str_compact(strip_tags(mb_strtolower($text, DEFAULT_CHARSET))) . ' ';
     $text = str_replace(['&#91;', '&#93;'], ['[', ']'], $text);
 
     // HTML entities like &nbsp;


### PR DESCRIPTION
- Removed migrations execution from Dockerfile build stage
- Added database connection check with retry logic in entrypoint
- Migrations now run after database is ready at container startup
- Fixed "database connection refused" error during image build

This fixes the issue where migrations were failing because they were executed during Docker image build when the database service was not yet available. Now migrations run at container startup after waiting for the database to be ready.