### PR TITLE
fix(database): prevent connection destruction during shutdown functions

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -121,7 +121,7 @@ class Database
     }
 
     /**
-     * Open connection using Nette Database
+     * Open a connection using Nette Database
      */
     public function connect(): void
     {
@@ -696,11 +696,9 @@ class Database
 
             $this->exec_shutdown_queries();
 
-            // Nette Database connection will be closed automatically
-            $this->connection = null;
+            // Nette Database connection will be closed automatically by PHP
+            // Do NOT set $this->connection = null here - other shutdown functions may still need it
         }
-
-        $this->selected_db = null;
     }
 
     /**


### PR DESCRIPTION
Remove explicit connection nullification in Database::close() to prevent race condition when multiple shutdown functions are registered.

**Problem:**
When Database::close() was registered as shutdown function, it would set $this->connection = null after executing shutdown queries. If other code registered shutdown functions after Database::connect() (e.g., admin_extensions.php), those functions would execute AFTER Database::close() and encounter null connection, causing "Call to a member function query() on null" errors.

**Shutdown execution order:**
1. Database::close() - executed shutdown queries, then set connection = null
2. update_attach_extensions() - tried to use already-null connection → CRASH

**Solution:**
Let PHP automatically close the connection when Database object is destroyed after ALL shutdown functions complete. Database::close() now only executes shutdown queries and releases locks, leaving connection alive for other shutdown functions.

**Impact:**
Fixes sporadic errors in admin panel when datastore updates are triggered via shutdown functions after database connection cleanup.