### PR TITLE
fix(privmsg): correct malformed checkbox name in PM list

### DIFF
--- a/resources/views/default/privmsgs.twig
+++ b/resources/views/default/privmsgs.twig
@@ -70,7 +70,7 @@
 	<td class="tLeft pad_0"><a href="{{ item.U_READ }}" class="med bold block pad_4">{{ item.SUBJECT|raw }}</a></td>
 	<td>{{ item.FROM|raw }}</td>
 	<td><u>{{ item.DATE_RAW }}</u>{{ item.DATE|raw }}</td>
-	<td><input type="checkbox" name="mark[]2" value="{{ item.S_MARK_ID }}" /></td>
+	<td><input type="checkbox" name="mark[]" value="{{ item.S_MARK_ID }}" /></td>
 </tr>
 {% endfor %}{# /LISTROW #}
 {% if NO_MESSAGES %}


### PR DESCRIPTION
## Summary
- Drop the stray `2` from `name="mark[]2"` on the PM list checkboxes in `resources/views/default/privmsgs.twig`, restoring the standard `name="mark[]"` array-input syntax already used elsewhere (`app/Http/Controllers/privmsg.php:346`).
- The typo was carried over from the legacy `.tpl` template during the Twig migration (#2282) and predates that — the controller reads the field with `request()->post->all('mark')`, which only works reliably when the input is named `mark[]`.

## Test plan
- [ ] Open Inbox / Sentbox / Outbox / Savebox under `pm.php`.
- [ ] Tick one or more message checkboxes and submit "Save marked" and "Delete marked" — confirm the selected messages are processed.
- [ ] Verify the rendered HTML contains `name="mark[]"` on each checkbox.

Fixes #2388

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bulk private message selection and processing. Message checkboxes now use consistent naming, ensuring selected messages are properly submitted for batch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->