### PR TITLE
security: harden actkey, unserialize and tracker race condition

### DIFF
--- a/app/Http/Controllers/Tracker/AnnounceController.php
+++ b/app/Http/Controllers/Tracker/AnnounceController.php
@@ -418,6 +418,8 @@ class AnnounceController
         $update_time = ($stopped) ? 0 : TIMENOW;
 
         if ($lp_info && empty($hybrid_unrecord)) {
+            // Compute up_add / down_add atomically against the row's current values to avoid
+            // double-counting when concurrent announces share the same stale lp_info cache.
             $sql = 'UPDATE ' . BB_BT_TRACKER . " SET update_time = {$update_time}";
 
             $sql .= ", {$ip_version} = '{$ip_sql}'";
@@ -427,12 +429,12 @@ class AnnounceController
 
             $sql .= ($tor_type != $lp_info['tor_type']) ? ", tor_type = {$tor_type}" : '';
 
-            $sql .= ($uploaded != $lp_info['uploaded']) ? ", uploaded = {$uploaded}" : '';
-            $sql .= ($downloaded != $lp_info['downloaded']) ? ", downloaded = {$downloaded}" : '';
-            $sql .= ", remain = {$left}";
+            $sql .= ", up_add = up_add + GREATEST(0, {$uploaded} - uploaded)";
+            $sql .= ", down_add = down_add + GREATEST(0, {$downloaded} - downloaded)";
 
-            $sql .= $up_add ? ", up_add = up_add + {$up_add}" : '';
-            $sql .= $down_add ? ", down_add = down_add + {$down_add}" : '';
+            $sql .= ", uploaded = {$uploaded}";
+            $sql .= ", downloaded = {$downloaded}";
+            $sql .= ", remain = {$left}";
 
             $sql .= ", speed_up = {$speed_up}";
             $sql .= ", speed_down = {$speed_down}";

--- a/app/Http/Controllers/Tracker/AnnounceController.php
+++ b/app/Http/Controllers/Tracker/AnnounceController.php
@@ -418,8 +418,16 @@ class AnnounceController
         $update_time = ($stopped) ? 0 : TIMENOW;
 
         if ($lp_info && empty($hybrid_unrecord)) {
-            // Compute up_add / down_add atomically against the row's current values to avoid
-            // double-counting when concurrent announces share the same stale lp_info cache.
+            // Mirror the freeleech/gold/silver discount applied to PHP-side $down_add for INSERT.
+            $down_ratio = '1';
+            if (config()->get('tracker.freeleech')
+                || (config()->get('tracker.gold_silver_enabled') && $tor_type == TOR_TYPE_GOLD)
+            ) {
+                $down_ratio = '0';
+            } elseif (config()->get('tracker.gold_silver_enabled') && $tor_type == TOR_TYPE_SILVER) {
+                $down_ratio = '0.5';
+            }
+
             $sql = 'UPDATE ' . BB_BT_TRACKER . " SET update_time = {$update_time}";
 
             $sql .= ", {$ip_version} = '{$ip_sql}'";
@@ -430,10 +438,10 @@ class AnnounceController
             $sql .= ($tor_type != $lp_info['tor_type']) ? ", tor_type = {$tor_type}" : '';
 
             $sql .= ", up_add = up_add + GREATEST(0, {$uploaded} - uploaded)";
-            $sql .= ", down_add = down_add + GREATEST(0, {$downloaded} - downloaded)";
+            $sql .= ", down_add = down_add + CEIL(GREATEST(0, {$downloaded} - downloaded) * {$down_ratio})";
 
-            $sql .= ", uploaded = {$uploaded}";
-            $sql .= ", downloaded = {$downloaded}";
+            $sql .= ", uploaded = GREATEST(uploaded, {$uploaded})";
+            $sql .= ", downloaded = GREATEST(downloaded, {$downloaded})";
             $sql .= ", remain = {$left}";
 
             $sql .= ", speed_up = {$speed_up}";

--- a/app/Http/Controllers/Tracker/AnnounceController.php
+++ b/app/Http/Controllers/Tracker/AnnounceController.php
@@ -437,8 +437,9 @@ class AnnounceController
 
             $sql .= ($tor_type != $lp_info['tor_type']) ? ", tor_type = {$tor_type}" : '';
 
-            $sql .= ", up_add = up_add + GREATEST(0, {$uploaded} - uploaded)";
-            $sql .= ", down_add = down_add + CEIL(GREATEST(0, {$downloaded} - downloaded) * {$down_ratio})";
+            // CAST AS SIGNED to dodge ER_DATA_OUT_OF_RANGE on stale-client underflow (BIGINT UNSIGNED columns).
+            $sql .= ", up_add = up_add + GREATEST(0, CAST({$uploaded} AS SIGNED) - CAST(uploaded AS SIGNED))";
+            $sql .= ", down_add = down_add + CEIL(GREATEST(0, CAST({$downloaded} AS SIGNED) - CAST(downloaded AS SIGNED)) * {$down_ratio})";
 
             $sql .= ", uploaded = GREATEST(uploaded, {$uploaded})";
             $sql .= ", downloaded = GREATEST(downloaded, {$downloaded})";

--- a/app/Http/Controllers/search.php
+++ b/app/Http/Controllers/search.php
@@ -343,7 +343,7 @@ if ($search_id) {
         bb_die(__('SESSION_EXPIRED'));
     }
 
-    $previous_settings = unserialize($row['search_settings']);
+    $previous_settings = unserialize($row['search_settings'], ['allowed_classes' => false]);
     $items_found = explode(',', $row['search_array']);
 }
 

--- a/app/Http/Controllers/tracker.php
+++ b/app/Http/Controllers/tracker.php
@@ -352,7 +352,7 @@ if ($search_id) {
         bb_die(__('SESSION_EXPIRED'));
     }
 
-    $previous_settings = unserialize($row['search_settings']);
+    $previous_settings = unserialize($row['search_settings'], ['allowed_classes' => false]);
     $tor_list_sql = $row['search_array'];
     $tor_list_ary = explode(',', $tor_list_sql);
     $tor_count = count($tor_list_ary);

--- a/config/auth.php
+++ b/config/auth.php
@@ -38,6 +38,7 @@ return [
     ],
     'first_logon_redirect_url' => '/',
     'invalid_logins' => 5,
+    'actkey_ttl' => 86400,
     'sessions' => [
         'update_interval' => 180,
         'user_duration' => 1209600,

--- a/config/tracker.php
+++ b/config/tracker.php
@@ -17,6 +17,7 @@ return [
 
     // IP handling
     'ignore_reported_ip' => false,
+    // Disable only behind a strictly trusted proxy: turning this off lets peers spoof their IP via X-Forwarded-For.
     'verify_reported_ip' => true,
     'allow_internal_ip' => false,
     'disallowed_ports' => [

--- a/database/migrations/20260509120000_add_actkey_time_to_users.php
+++ b/database/migrations/20260509120000_add_actkey_time_to_users.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * TorrentPier – Bull-powered BitTorrent tracker engine
+ *
+ * @copyright Copyright (c) 2005-2025 TorrentPier (https://torrentpier.com)
+ * @link      https://github.com/torrentpier/torrentpier for the canonical source repository
+ * @license   https://github.com/torrentpier/torrentpier/blob/master/LICENSE MIT License
+ */
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddActkeyTimeToUsers extends AbstractMigration
+{
+    public function up(): void
+    {
+        $this->table('bb_users')
+            ->addColumn('user_actkey_time', 'integer', [
+                'default' => 0,
+                'null' => false,
+                'after' => 'user_actkey',
+            ])
+            ->update();
+    }
+
+    public function down(): void
+    {
+        $this->table('bb_users')
+            ->removeColumn('user_actkey_time')
+            ->update();
+    }
+}

--- a/library/includes/ucp/activate.php
+++ b/library/includes/ucp/activate.php
@@ -12,7 +12,7 @@ if (!request()->query->has(POST_USERS_URL) || !request()->query->has('act_key'))
     bb_die('Bad request');
 }
 
-$sql = 'SELECT user_active, user_id, username, user_email, user_newpasswd, user_lang, user_actkey
+$sql = 'SELECT user_active, user_id, username, user_email, user_newpasswd, user_lang, user_actkey, user_actkey_time
 	FROM ' . BB_USERS . '
 	WHERE user_id = ' . request()->query->getInt(POST_USERS_URL);
 if (!($result = DB()->sql_query($sql))) {
@@ -20,13 +20,20 @@ if (!($result = DB()->sql_query($sql))) {
 }
 
 if ($row = DB()->sql_fetchrow($result)) {
-    if ($row['user_active'] && trim($row['user_actkey']) == '') {
+    $stored_actkey = trim($row['user_actkey']);
+    $supplied_actkey = trim((string)request()->query->get('act_key'));
+    $actkey_ttl = (int)config()->get('auth.actkey_ttl');
+    $actkey_expired = $actkey_ttl > 0
+        && (int)$row['user_actkey_time'] > 0
+        && (TIMENOW - (int)$row['user_actkey_time']) > $actkey_ttl;
+
+    if ($row['user_active'] && $stored_actkey === '') {
         bb_die(__('ALREADY_ACTIVATED'));
-    } elseif ((trim($row['user_actkey']) == trim(request()->query->get('act_key'))) && (trim($row['user_actkey']) != '')) {
+    } elseif ($stored_actkey !== '' && !$actkey_expired && hash_equals($stored_actkey, $supplied_actkey)) {
         $sql_update_pass = ($row['user_newpasswd'] != '') ? ", user_password = '" . user()->password_hash($row['user_newpasswd']) . "', user_newpasswd = ''" : '';
 
         $sql = 'UPDATE ' . BB_USERS . "
-			SET user_active = 1, user_actkey = ''" . $sql_update_pass . '
+			SET user_active = 1, user_actkey = '', user_actkey_time = 0" . $sql_update_pass . '
 			WHERE user_id = ' . $row['user_id'];
         if (!($result = DB()->sql_query($sql))) {
             bb_die('Could not update users table');

--- a/library/includes/ucp/register.php
+++ b/library/includes/ucp/register.php
@@ -571,15 +571,18 @@ if ($submit && !$errors) {
             $user_actkey = Str::random(ACTKEY_LENGTH);
             $db_data['user_active'] = 0;
             $db_data['user_actkey'] = $user_actkey;
+            $db_data['user_actkey_time'] = TIMENOW;
         } else {
             $db_data['user_active'] = 1;
             $db_data['user_actkey'] = '';
+            $db_data['user_actkey_time'] = 0;
         }
         // Force email activation for spam-moderated users
         if (isset($spamResult) && $spamResult->isModerated()) {
             $user_actkey = Str::random(ACTKEY_LENGTH);
             $db_data['user_active'] = 0;
             $db_data['user_actkey'] = $user_actkey;
+            $db_data['user_actkey_time'] = TIMENOW;
         }
 
         $db_data['user_regdate'] = TIMENOW;
@@ -653,6 +656,7 @@ if ($submit && !$errors) {
                 $user_actkey = Str::random(ACTKEY_LENGTH);
                 $pr_data['user_actkey'] = $user_actkey;
                 $db_data['user_actkey'] = $user_actkey;
+                $db_data['user_actkey_time'] = TIMENOW;
 
                 // Sending email
                 $emailer = new TorrentPier\Emailer;

--- a/library/includes/ucp/sendpasswd.php
+++ b/library/includes/ucp/sendpasswd.php
@@ -40,8 +40,8 @@ if (request()->post->has('submit')) {
             $user_password = Str::random(PASSWORD_MIN_LENGTH);
 
             $sql = 'UPDATE ' . BB_USERS . "
-				SET user_newpasswd = '{$user_password}', user_actkey = '{$user_actkey}'
-				WHERE user_id = " . $row['user_id'];
+				SET user_newpasswd = '{$user_password}', user_actkey = '{$user_actkey}', user_actkey_time = " . TIMENOW . '
+				WHERE user_id = ' . $row['user_id'];
             if (!DB()->sql_query($sql)) {
                 bb_die('Could not update new password information');
             }


### PR DESCRIPTION
## Summary

Outcome of an internal security pass on the public-facing surface (controllers, tracker, auth flows). Three independent fixes, each in its own commit so the diff stays reviewable.

- `security: harden search/tracker unserialize against object injection` — pass `['allowed_classes' => false]` to `unserialize()` in `app/Http/Controllers/search.php:346` and `app/Http/Controllers/tracker.php:355`. Today the payload is built from `serialize()` of a scalar settings array, but the second argument is defense in depth: any future SQL or DB write primitive would otherwise turn this read into a PHP object injection sink.
- `security: enforce TTL and constant-time check on user_actkey` — `bb_users.user_actkey` had no lifetime and was compared with `==` in `library/includes/ucp/activate.php:25`, so a token leaked years ago (or sniffed once) could still take over an account. Adds a `user_actkey_time` column (Phinx migration), stamps `TIMENOW` on every actkey generation site (registration, edit reactivation, password recovery), checks `hash_equals()` on the supplied key and rejects keys older than `auth.actkey_ttl` seconds (24h default; set to `0` to disable on legacy installs). Also adds a one-line comment near `tracker.verify_reported_ip` warning that disabling it allows X-Forwarded-For spoofing.
- `security(tracker): compute peer stat deltas atomically` — `up_add` / `down_add` were calculated in PHP from the cached `lp_info` snapshot, which two concurrent announces from the same peer can share. Both then issued `UPDATE ... up_add = up_add + delta` with the same `delta`, double-crediting (or losing) traffic against the row. Switches to `GREATEST(0, $value - <column>)` inside the same `UPDATE` so the delta is taken from the row's current value, making the increment race-free without changing call signatures or the cache layer.

CSRF protection was identified during the audit as the largest remaining gap (no token check on any public POST handler — login, posting, privmsg, profile, poll, modcp, group; only `SameSite=Lax` mitigates today). It is intentionally **out of scope here** because it requires a new middleware, a `csrf_token()` helper, and a touch on every form template; will follow in its own PR.

## Test plan
- [x] `vendor/bin/pest` — 1542 passed, 30 skipped, 0 failures
- [x] PHP `-l` syntax check on each modified file
- [ ] Run the new `20260509120000_add_actkey_time_to_users` migration on a staging DB and verify the column lands `AFTER user_actkey` with `default 0`
- [ ] Trigger password recovery, wait > `auth.actkey_ttl`, confirm the link returns `WRONG_ACTIVATION`
- [ ] Trigger password recovery, click within TTL, confirm activation succeeds and `user_actkey_time` is reset to \`0\`
- [ ] Two concurrent announces from the same peer with the same \`uploaded\` value should produce a single \`up_add\` increment (use \`mysqlbinlog\` or query log on the tracker DB to confirm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activation keys now expire after a configurable time period for enhanced account security.

* **Bug Fixes**
  * Improved session security with safer data deserialization.
  * Enhanced tracker peer statistics calculations with discount support and underflow protection.

* **Configuration**
  * Added configurable activation key expiration setting (default: 24 hours).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->