### PR TITLE
security: add CSRF token verification to public POST handlers

### DIFF
--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * TorrentPier – Bull-powered BitTorrent tracker engine
+ *
+ * @copyright Copyright (c) 2005-2025 TorrentPier (https://torrentpier.com)
+ * @link      https://github.com/torrentpier/torrentpier for the canonical source repository
+ * @license   https://github.com/torrentpier/torrentpier/blob/master/LICENSE MIT License
+ */
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Laminas\Diactoros\Response\TextResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use TorrentPier\Http\Csrf;
+
+/**
+ * Reject state-changing requests that lack a valid CSRF token.
+ *
+ * Token is read from `_token` POST field, falling back to the `X-CSRF-Token`
+ * header for AJAX. GET/HEAD/OPTIONS pass through but still trigger token
+ * generation so subsequent POSTs have something to send.
+ */
+final class VerifyCsrfToken implements MiddlewareInterface
+{
+    public function process(
+        ServerRequestInterface  $request,
+        RequestHandlerInterface $handler,
+    ): ResponseInterface {
+        $method = strtoupper($request->getMethod());
+
+        // Always touch the token so guest GETs warm the cache for their next POST.
+        Csrf::token();
+
+        if (!\in_array($method, Csrf::protectedMethods(), true)) {
+            return $handler->handle($request);
+        }
+
+        $supplied = null;
+        $parsed = $request->getParsedBody();
+        if (\is_array($parsed) && isset($parsed[Csrf::FIELD]) && \is_string($parsed[Csrf::FIELD])) {
+            $supplied = $parsed[Csrf::FIELD];
+        }
+        if ($supplied === null && $request->hasHeader(Csrf::HEADER)) {
+            $supplied = $request->getHeaderLine(Csrf::HEADER);
+        }
+
+        if (!Csrf::verify($supplied)) {
+            return new TextResponse('CSRF token mismatch.', 419);
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -25,6 +25,7 @@ use App\Http\Middleware\Admin;
 use App\Http\Middleware\Authenticate;
 use App\Http\Middleware\StartSession;
 use App\Http\Middleware\Tracker;
+use App\Http\Middleware\VerifyCsrfToken;
 use TorrentPier\Application;
 use TorrentPier\Exceptions\Handler;
 use TorrentPier\Http\Middleware;
@@ -108,6 +109,7 @@ return Application::configure(basePath: dirname(__DIR__))
         // Middleware aliases for route definitions
         $middleware->alias('session', StartSession::class);
         $middleware->alias('auth', Authenticate::class);
+        $middleware->alias('csrf', VerifyCsrfToken::class);
         $middleware->alias('tracker', Tracker\BootTracker::class);
         $middleware->alias('admin', Admin\EnsureAdmin::class);
     })

--- a/public/assets/js/main.js
+++ b/public/assets/js/main.js
@@ -230,6 +230,30 @@ var Menu = {
 };
 
 $(document).ready(function () {
+  // CSRF: pull token from <meta name="csrf-token"> and attach to every same-origin AJAX request.
+  var _csrfToken = $('meta[name="csrf-token"]').attr('content') || '';
+  if (_csrfToken) {
+    $.ajaxSetup({
+      beforeSend: function (xhr, settings) {
+        var crossDomain = settings.crossDomain;
+        var url = settings.url || '';
+        var sameOrigin = !crossDomain && !/^https?:\/\//i.test(url);
+        if (sameOrigin && !/^(GET|HEAD|OPTIONS)$/i.test(settings.type || 'GET')) {
+          xhr.setRequestHeader('X-CSRF-Token', _csrfToken);
+        }
+      }
+    });
+    if (typeof Ajax !== 'undefined' && Ajax.prototype) {
+      Ajax.prototype.form_token = _csrfToken;
+    }
+    // Auto-inject hidden _token into every POST form rendered without csrf_field().
+    $('form').each(function () {
+      if (((this.method || '').toUpperCase() === 'POST') && !$(this).find('input[name="_token"]').length) {
+        $('<input>').attr({ type: 'hidden', name: '_token', value: _csrfToken }).appendTo(this);
+      }
+    });
+  }
+
   // Menus
   $('body').append($('div.menu-sub'));
   $('a.menu-root')

--- a/public/assets/js/main.js
+++ b/public/assets/js/main.js
@@ -230,27 +230,38 @@ var Menu = {
 };
 
 $(document).ready(function () {
-  // CSRF: pull token from <meta name="csrf-token"> and attach to every same-origin AJAX request.
   var _csrfToken = $('meta[name="csrf-token"]').attr('content') || '';
   if (_csrfToken) {
+    // Resolve url against current location and compare origins so absolute
+    // same-origin URLs (e.g. SITE_URL-prefixed AJAX endpoints) are not skipped
+    // and protocol-relative cross-origin URLs do not leak the token.
+    var _isSameOrigin = function (url) {
+      if (!url) return true;
+      try {
+        return new URL(url, window.location.href).origin === window.location.origin;
+      } catch (e) {
+        return true;
+      }
+    };
+
     $.ajaxSetup({
       beforeSend: function (xhr, settings) {
-        var crossDomain = settings.crossDomain;
-        var url = settings.url || '';
-        var sameOrigin = !crossDomain && !/^https?:\/\//i.test(url);
-        if (sameOrigin && !/^(GET|HEAD|OPTIONS)$/i.test(settings.type || 'GET')) {
-          xhr.setRequestHeader('X-CSRF-Token', _csrfToken);
-        }
+        if (settings.crossDomain) return;
+        if (/^(GET|HEAD|OPTIONS)$/i.test(settings.type || 'GET')) return;
+        if (!_isSameOrigin(settings.url || '')) return;
+        xhr.setRequestHeader('X-CSRF-Token', _csrfToken);
       }
     });
     if (typeof Ajax !== 'undefined' && Ajax.prototype) {
       Ajax.prototype.form_token = _csrfToken;
     }
-    // Auto-inject hidden _token into every POST form rendered without csrf_field().
-    $('form').each(function () {
-      if (((this.method || '').toUpperCase() === 'POST') && !$(this).find('input[name="_token"]').length) {
-        $('<input>').attr({ type: 'hidden', name: '_token', value: _csrfToken }).appendTo(this);
-      }
+    // Inject hidden _token at submit time so dynamically-added forms are covered
+    // and the token never leaks to a form action pointing at another origin.
+    $(document).on('submit', 'form', function () {
+      if ((this.method || '').toUpperCase() !== 'POST') return;
+      if (!_isSameOrigin($(this).attr('action') || '')) return;
+      if ($(this).find('input[name="_token"]').length) return;
+      $('<input>').attr({ type: 'hidden', name: '_token', value: _csrfToken }).appendTo(this);
     });
   }
 

--- a/resources/views/default/group.twig
+++ b/resources/views/default/group.twig
@@ -53,6 +53,7 @@
 <!--========================================================================-->
 
 <form action="{{ S_GROUP_ACTION }}" method="post">
+    {{ csrf_field() }}
     {{ S_HIDDEN_FIELDS|raw }}
 
     <table class="forumline pad_4">
@@ -127,6 +128,7 @@
 
 {% if MEMBERS %}
 <form action="{{ S_GROUP_ACTION }}" method="post" name="post">
+    {{ csrf_field() }}
     {{ S_HIDDEN_FIELDS|raw }}
 
     <table class="forumline tablesorter">

--- a/resources/views/default/group_edit.twig
+++ b/resources/views/default/group_edit.twig
@@ -104,6 +104,7 @@
             {% if config('avatars.group.up_allowed') %}
             <br/>
             <form action="{{ S_GROUP_CONFIG_ACTION }}" method="post" enctype="multipart/form-data">
+                {{ csrf_field() }}
                 {{ S_HIDDEN_FIELDS|raw }}
                 <input type="hidden" name="MAX_FILE_SIZE" value="{{ config('avatars.group.max_size') }}"/>
                 <input type="file" name="avatar" accept="image/*"/>

--- a/resources/views/default/login.twig
+++ b/resources/views/default/login.twig
@@ -1,7 +1,7 @@
 <h1 class="pagetitle">{{ PAGE_TITLE }}</h1>
 
 <form action="{{ S_LOGIN_ACTION }}" method="post">
-
+    {{ csrf_field() }}
     <input type="hidden" name="redirect" value="{{ REDIRECT_URL }}"/>
     {% if ADMIN_LOGIN %}<input type="hidden" name="admin" value="1"/>{% endif %}
 

--- a/resources/views/default/login_2fa.twig
+++ b/resources/views/default/login_2fa.twig
@@ -1,7 +1,7 @@
 <h1 class="pagetitle">{{ PAGE_TITLE }}</h1>
 
 <form action="{{ S_LOGIN_ACTION }}" method="post" class="tokenized">
-
+    {{ csrf_field() }}
     <input type="hidden" name="redirect" value="{{ REDIRECT_URL }}"/>
     <input type="hidden" name="2fa_token" value="{{ TWO_FA_TOKEN }}"/>
 
@@ -69,6 +69,7 @@
 <div class="tCenter pad_4">
 {% if not USE_RECOVERY %}
 <form action="{{ S_LOGIN_ACTION }}" method="post" style="display:inline" class="tokenized">
+    {{ csrf_field() }}
     <input type="hidden" name="2fa_token" value="{{ TWO_FA_TOKEN }}"/>
     <input type="hidden" name="redirect" value="{{ REDIRECT_URL }}"/>
     <input type="hidden" name="switch_2fa_mode" value="recovery"/>
@@ -76,6 +77,7 @@
 </form>
 {% else %}
 <form action="{{ S_LOGIN_ACTION }}" method="post" style="display:inline" class="tokenized">
+    {{ csrf_field() }}
     <input type="hidden" name="2fa_token" value="{{ TWO_FA_TOKEN }}"/>
     <input type="hidden" name="redirect" value="{{ REDIRECT_URL }}"/>
     <input type="hidden" name="switch_2fa_mode" value="totp"/>

--- a/resources/views/default/memberlist.twig
+++ b/resources/views/default/memberlist.twig
@@ -1,6 +1,7 @@
 <h1 class="pagetitle">{{ PAGE_TITLE }}</h1>
 
 <form method="post" action="{{ S_MODE_ACTION }}" name="post">
+    {{ csrf_field() }}
     <table width="100%">
         <tr>
             <td class="med nowrap tRight">{{ __('SORT_BY') }}:&nbsp;{{ S_MODE_SELECT|raw }}&nbsp;&middot;&nbsp;{{ __('ORDER') }}:&nbsp;{{ S_ORDER_SELECT|raw }}&nbsp;&middot;&nbsp;{{ __('ROLE') }}&nbsp;{{ S_ROLE_SELECT|raw }}&nbsp;<input type="submit" name="submit" value="{{ __('SUBMIT') }}"></td>

--- a/resources/views/default/modcp.twig
+++ b/resources/views/default/modcp.twig
@@ -55,6 +55,7 @@
 <!--========================================================================-->
 
 <form action="{{ S_MODCP_ACTION }}" method="post">
+{{ csrf_field() }}
 {{ S_HIDDEN_FIELDS|raw }}
 
 <table class="forumline">

--- a/resources/views/default/modcp_split.twig
+++ b/resources/views/default/modcp_split.twig
@@ -16,7 +16,7 @@ function toggle_cbox (cb_id, tr_id)
 <style> .sel { background-color:#FFEFD5; } </style>
 
 <form method="post" action="{{ S_SPLIT_ACTION }}">
-
+{{ csrf_field() }}
 <table width="100%">
 	<tr>
 		<td style="padding-left: 0;" class="nav">

--- a/resources/views/default/page_header.twig
+++ b/resources/views/default/page_header.twig
@@ -5,6 +5,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=Edge">
 <meta name="viewport" content="initial-scale=1.0">
 <meta name="generator" content="{{ constant('APP_NAME') }}">
+<meta name="csrf-token" content="{{ csrf_token() }}">
 {% if META_DESCRIPTION %}
 <meta name="description" content="{{ META_DESCRIPTION }}"/>
 <meta property="og:description" content="{{ META_DESCRIPTION }}">

--- a/resources/views/default/page_header.twig
+++ b/resources/views/default/page_header.twig
@@ -299,6 +299,7 @@ function go_to_page ()
 			<td class="tCenter pad_2">
 				<a href="{{ U_REGISTER }}" id="register_link"><b>{{ __('REGISTER') }}</b></a> &#0183;
 					<form action="{{ S_LOGIN_ACTION }}" method="post">
+						{{ csrf_field() }}
 						{{ __('USERNAME') }}: <input type="text" name="login_username" size="12" tabindex="1" accesskey="l" />
 						{{ __('PASSWORD') }}: <input type="password" name="login_password" size="12" tabindex="2" />
 						<label title="{{ __('AUTO_LOGIN') }}"><input type="checkbox" name="autologin" value="1" tabindex="3" checked />{{ __('REMEMBER') }}</label>&nbsp;

--- a/resources/views/default/posting.twig
+++ b/resources/views/default/posting.twig
@@ -58,6 +58,7 @@
 </p>
 
 <form action="{{ S_POST_ACTION }}" method="post" name="post" onsubmit="if(checkForm(this)){ dis_submit_btn(); }else{ return false; }" {{ S_FORM_ENCTYPE }}>
+    {{ csrf_field() }}
     {{ S_HIDDEN_FORM_FIELDS|raw }}
     {{ ADD_ATTACH_HIDDEN_FIELDS|raw }}
     {{ POSTED_ATTACHMENTS_HIDDEN_FIELDS|raw }}

--- a/resources/views/default/posting_tpl.twig
+++ b/resources/views/default/posting_tpl.twig
@@ -4831,6 +4831,7 @@ $(function(){
 
 <div style="display: none;">
 <form id="tpl-post-form" method="post" action="{TPL_FORM_ACTION}" name="post" class="tokenized">
+	{{ csrf_field() }}
 	<input type="hidden" name="tor_required" value="{TOR_REQUIRED}">
 	<input type="hidden" name="preview" value="1">
 	<input id="tpl-post-subject" type="text" name="subject" size="90" value="" />

--- a/resources/views/default/privmsgs.twig
+++ b/resources/views/default/privmsgs.twig
@@ -40,6 +40,7 @@
 <div class="spacer_6"></div>
 
 <form method="post" name="privmsg_list" action="{{ S_PRIVMSGS_ACTION }}">
+{{ csrf_field() }}
 {{ S_HIDDEN_FIELDS|raw }}
 
 <table width="100%">

--- a/resources/views/default/privmsgs_read.twig
+++ b/resources/views/default/privmsgs_read.twig
@@ -14,6 +14,7 @@
 <div class="spacer_6"></div>
 
 <form action="{{ S_PRIVMSGS_ACTION }}" method="post" name="post" onsubmit="if(checkForm(this)){ dis_submit_btn(); }else{ return false; }">
+{{ csrf_field() }}
 {{ S_HIDDEN_FIELDS|raw }}
 
 <table class="borderless">
@@ -75,6 +76,7 @@
     };
 </script>
 <form action="{{ S_PRIVMSGS_ACTION }}" method="post" name="post" onsubmit="if(checkForm(this)){ dis_submit_btn(); }else{ return false; }">
+{{ csrf_field() }}
 {{ S_HIDDEN_FIELDS|raw }}
 
 <table class="topic" cellpadding="0" cellspacing="0">

--- a/resources/views/default/search.twig
+++ b/resources/views/default/search.twig
@@ -7,6 +7,7 @@
 <p class="nav"><a href="{{ U_INDEX }}">{{ __('HOME') }}</a></p>
 
 <form action="{{ SEARCH_ACTION }}" method="POST" name="post">
+{{ csrf_field() }}
 {{ S_HIDDEN_FIELDS|raw }}
 
 <table class="forumline fieldsets">
@@ -140,7 +141,7 @@
 </script>
 
 <form method="post" name="search" action="{{ SEARCH_ACTION }}">
-
+{{ csrf_field() }}
 <table class="bordered search_username">
 <tr>
 	<th class="thHead">{{ __('FIND_USERNAME') }}</th>

--- a/resources/views/default/search_results.twig
+++ b/resources/views/default/search_results.twig
@@ -75,6 +75,7 @@
 
 {% if DL_CONTROLS %}
 <form method="POST" action="{{ DL_ACTION }}">
+{{ csrf_field() }}
 {% elseif MY_POSTS %}
 <script type="text/javascript">
 ajax.in_edit_mode = false;
@@ -124,6 +125,7 @@ function show_edit_options ()
 
 <div id="mod-action-content" style="display: none;">
 <form id="mod-action" method="POST" action="{{ U_SEARCH }}" target="_blank">
+    {{ csrf_field() }}
     <table class="borderless pad_0" cellpadding="0" cellspacing="0">
         <tr>
             <td class="pad_4">

--- a/resources/views/default/tracker.twig
+++ b/resources/views/default/tracker.twig
@@ -161,6 +161,7 @@ ajax.callback.view_post = function(data) {
 </div>
 
 <form method="POST" name="post" action="{{ TOR_SEARCH_ACTION }}#results">
+{{ csrf_field() }}
 {{ S_HIDDEN_FIELDS }}
 
 <table class="bordered w100" cellspacing="0">

--- a/resources/views/default/usercp_bonus.twig
+++ b/resources/views/default/usercp_bonus.twig
@@ -10,7 +10,7 @@
 </table>
 
 <form method="post" name="bonus_list" action="{{ S_MODE_ACTION }}">
-
+{{ csrf_field() }}
 <table class="forumline tCenter">
 <tr>
 	<th colspan="3">{{ MY_BONUS|raw }}</th>

--- a/resources/views/default/usercp_email.twig
+++ b/resources/views/default/usercp_email.twig
@@ -3,6 +3,7 @@
 <p class="nav"><a href="{{ U_INDEX }}">{{ __('HOME') }}</a></p>
 
 <form action="{{ S_POST_ACTION }}" method="post" name="post" onSubmit="return checkForm(this);">
+{{ csrf_field() }}
 {{ S_HIDDEN_FIELDS|raw }}
 
 <table class="forumline">

--- a/resources/views/default/usercp_register.twig
+++ b/resources/views/default/usercp_register.twig
@@ -51,6 +51,7 @@
 
 <form id="prof-form" method="post" action="{% if IS_ADMIN and PR_USER_ID %}?{{ constant('POST_USERS_URL') }}={{ PR_USER_ID }}{% endif %}"
       class="tokenized" enctype="multipart/form-data">
+    {{ csrf_field() }}
     <input type="hidden" name="mode" value="{{ MODE }}"/>
     <input type="hidden" name="reg_agreed" value="1"/>
     {% if NEW_USER %}<input type="hidden" name="admin" value="1"/>{% endif %}

--- a/resources/views/default/usercp_sendpasswd.twig
+++ b/resources/views/default/usercp_sendpasswd.twig
@@ -8,6 +8,7 @@ ajax.callback.user_register = function(data){
 <p class="nav"><a href="{{ U_INDEX }}">{{ __('HOME') }}</a></p>
 
 <form action="{{ S_PROFILE_ACTION }}" method="post">
+{{ csrf_field() }}
 {{ S_HIDDEN_FIELDS|raw }}
 
 <table class="forumline">

--- a/resources/views/default/usercp_topic_watch.twig
+++ b/resources/views/default/usercp_topic_watch.twig
@@ -53,6 +53,7 @@
 
 <div id="mod-action-content" style="display: none;">
     <form id="mod-action" name="watch_form" method="post" action="{{ S_FORM_ACTION }}">
+        {{ csrf_field() }}
         <table class="borderless pad_0" cellpadding="0" cellspacing="0">
             <tr>
                 <td class="pad_4">

--- a/resources/views/default/usercp_twofactor_disable.twig
+++ b/resources/views/default/usercp_twofactor_disable.twig
@@ -7,7 +7,7 @@
 </p>
 
 <form method="post" action="{{ FORUM_PATH }}profile/two-step?action=disable" class="tokenized">
-
+{{ csrf_field() }}
 <table class="forumline">
     <col class="row1" width="35%">
     <col class="row2" width="65%">

--- a/resources/views/default/usercp_twofactor_regenerate.twig
+++ b/resources/views/default/usercp_twofactor_regenerate.twig
@@ -7,7 +7,7 @@
 </p>
 
 <form method="post" action="{{ FORUM_PATH }}profile/two-step?action=regenerate" class="tokenized">
-
+{{ csrf_field() }}
 <table class="forumline">
     <col class="row1" width="35%">
     <col class="row2" width="65%">

--- a/resources/views/default/usercp_twofactor_setup.twig
+++ b/resources/views/default/usercp_twofactor_setup.twig
@@ -33,6 +33,7 @@
     <tr>
         <td colspan="2">
             <form method="post" action="{{ FORUM_PATH }}profile/two-step?action=enable" class="tokenized">
+                {{ csrf_field() }}
                 <input type="hidden" name="setup_token" value="{{ SETUP_TOKEN }}"/>
                 <table class="borderless bCenter" style="width: 400px;">
                     <tr>

--- a/resources/views/default/viewforum.twig
+++ b/resources/views/default/viewforum.twig
@@ -153,6 +153,7 @@ ajax.callback.mod_action = function (data) {
 
 <div id="mod-action-content" style="display: none;">
 <form id="mod-action" method="post" action="/modcp" class="tokenized">
+	{{ csrf_field() }}
 	<input type="hidden" name="{{ constant('POST_FORUM_URL') }}" value="{{ FORUM_ID }}" />
 	<div class="floatL">
 	<input type="checkbox" onclick="$('.topic-chbox').attr({ checked: this.checked }); if(this.checked){$('.tt-text').addClass('hl-tt');}else{$('.tt-text').removeClass('hl-tt');}" />
@@ -373,7 +374,7 @@ td.topic_id { cursor: pointer; }
 		<td class="med" style="padding: 0 4px 2px 4px;color:#CDCDCD">|</td>
 		<td class="small nowrap" style="padding: 0;">{{ __('TOPICS_PER_PAGE') }}:</td>
 		<td class="small nowrap" style="padding: 0 0 0 3px;">
-			<form id="tpp" action="{{ PAGE_URL_TPP }}" method="post">{{ SELECT_TPP|raw }}</form>
+			<form id="tpp" action="{{ PAGE_URL_TPP }}" method="post">{{ csrf_field() }}{{ SELECT_TPP|raw }}</form>
 		</td>
 		{% if TORRENTS %}
 		<td class="small nowrap" style="padding: 0 0 0 6px;">{{ __('STATUS') }}:</td>
@@ -401,6 +402,7 @@ td.topic_id { cursor: pointer; }
 
 		<td class="nowrap" style="padding: 0 4px 2px 4px;">
 			<form action="{{ PAGE_URL }}" method="post">
+				{{ csrf_field() }}
 				<input id="search-text" type="text" name="nm"
 				{% if TITLE_MATCH %}
 					value="{{ TITLE_MATCH }}" required {% if FOUND_TOPICS %}class="found"{% else %}class="error"{% endif %}
@@ -507,6 +509,7 @@ td.topic_id { cursor: pointer; }
 	<td colspan="6" class="catBottom med pad_4">
 	{% if LOGGED_IN %}
 	<form method="post" action="{{ S_POST_DAYS_ACTION }}">
+		{{ csrf_field() }}
 		{{ __('DISPLAY_TOPICS') }}: {{ S_SELECT_TOPIC_DAYS|raw }} {{ S_DISPLAY_ORDER|raw }}
 		<input type="submit" value="{{ __('GO') }}" />
 	</form>
@@ -580,6 +583,7 @@ td.topic_id { cursor: pointer; }
 	<td colspan="7" class="catBottom med pad_4">
 	{% if LOGGED_IN %}
 	<form method="post" action="{{ S_POST_DAYS_ACTION }}">
+		{{ csrf_field() }}
 		{{ __('DISPLAY_TOPICS') }}: {{ S_SELECT_TOPIC_DAYS|raw }} {{ S_DISPLAY_ORDER|raw }}
 		<input type="submit" value="{{ __('GO') }}" />
 	</form>

--- a/resources/views/default/viewtopic.twig
+++ b/resources/views/default/viewtopic.twig
@@ -202,6 +202,7 @@ ajax.callback.post_mod_comment = function(data) {
 
 {% if TOPIC_HAS_POLL or CAN_MANAGE_POLL %}
 <form id="poll-form" method="post" action="/poll" style="display: none;">
+{{ csrf_field() }}
 <input id="poll-mode" type="hidden" name="mode" value="" />
 <input type="hidden" name="topic_id" value="{{ TOPIC_ID }}" />
 <input type="hidden" name="{{ TOPIC_HASH }}" value="1" />
@@ -276,7 +277,7 @@ function build_poll_add_form (src_el)
 		<td class="med" style="padding: 0 4px 2px 4px;">|</td>
 		<td class="small nowrap" style="padding: 0 0 0 0;">{{ __('SELECT_POSTS_PER_PAGE') }}</td>
 		<td class="small nowrap" style="padding: 0 0 0 3px;">
-			<form id="ppp" action="{{ PAGE_URL_PPP }}" method="post">{{ SELECT_PPP|raw }}</form>
+			<form id="ppp" action="{{ PAGE_URL_PPP }}" method="post">{{ csrf_field() }}{{ SELECT_PPP|raw }}</form>
 		</td>
 		{% endif %}
 		{% endif %}
@@ -291,6 +292,7 @@ function build_poll_add_form (src_el)
 
 		<td class="nowrap" style="padding: 0 4px 2px 4px;">
 			<form action="{{ U_SEARCH }}?{{ constant('POST_TOPIC_URL') }}={{ TOPIC_ID }}&amp;dm=1&amp;s=1" method="post">
+				{{ csrf_field() }}
 				<input id="search-text" type="text" name="nm" class="hint" style="width: 150px;" placeholder="{{ __('SEARCH_IN_TOPIC') }}" required />
 				<input type="submit" class="bold" value="&raquo;" style="width: 30px;" />
 			</form>
@@ -528,6 +530,7 @@ function build_poll_add_form (src_el)
 <tr id="del_split_row" class="row5" style="display: none;">
 	<td colspan="2" class="med pad_4 td2">
 	<form method="post" action="{{ S_SPLIT_ACTION }}">
+	{{ csrf_field() }}
 	<input type="hidden" name="redirect" value="modcp?{{ constant('POST_TOPIC_URL') }}={{ TOPIC_ID }}&amp;mode=split" />
 	<input type="hidden" name="{{ constant('POST_FORUM_URL') }}" value="{{ FORUM_ID }}" />
 	<input type="hidden" name="{{ constant('POST_TOPIC_URL') }}" value="{{ TOPIC_ID }}" />
@@ -585,6 +588,7 @@ function build_poll_add_form (src_el)
     <tr>
         <td class="catBottom med">
             <form method="post" action="{{ S_POST_DAYS_ACTION }}">
+                {{ csrf_field() }}
                 {{ __('DISPLAY_POSTS') }}: {{ S_SELECT_POST_DAYS|raw }}&nbsp;
                 {{ S_SELECT_POST_ORDER|raw }}&nbsp;
                 <input type="submit" value="{{ __('GO') }}" class="lite" name="submit" />
@@ -607,6 +611,7 @@ function build_poll_add_form (src_el)
 {% if QUICK_REPLY %}
 <br/>
 <form action="{{ QR_POST_ACTION }}" method="post" name="post" onsubmit="if(checkForm(this)){ dis_submit_btn(); }else{ return false; }">
+{{ csrf_field() }}
 <input type="hidden" name="mode" value="reply" />
 <input type="hidden" name="{{ constant('POST_TOPIC_URL') }}" value="{{ QR_TOPIC_ID }}" />
 

--- a/resources/views/default/viewtopic_torrent.twig
+++ b/resources/views/default/viewtopic_torrent.twig
@@ -248,7 +248,7 @@ ajax.callback.callseed = function (data) {
 <tr>
 	<td colspan="2" class="row3 pad_4">
 	{% if DL_BUTTONS %}
-	<form method="POST" action="{{ S_DL_ACTION }}">{{ DL_HIDDEN_FIELDS|raw }}
+	<form method="POST" action="{{ S_DL_ACTION }}">{{ csrf_field() }}{{ DL_HIDDEN_FIELDS|raw }}
 		{% if DL_BUT_WILL %}<input type="submit" name="dl_set_will" value="{{ __('DLWILL') }}" class="liteoption" />&nbsp;{% endif %}
 		{% if DL_BUT_DOWN %}<input type="submit" name="dl_set_down" value="{{ __('DLDOWN') }}" class="liteoption" />&nbsp;{% endif %}
 		{% if DL_BUT_COMPL %}<input type="submit" name="dl_set_complete" value="{{ __('DLCOMPLETE') }}" class="liteoption" />&nbsp;{% endif %}

--- a/routes/api.php
+++ b/routes/api.php
@@ -72,5 +72,5 @@ return static function (Router $router): void {
         $group->post('/manage-user', ManageUserController::class)->middleware(new EnsureRole('admin'));
         $group->post('/manage-admin', ManageAdminController::class)->middleware(new EnsureRole('admin'));
         $group->post('/sitemap', SitemapController::class)->middleware(new EnsureRole('admin'));
-    })->middleware('session');
+    })->middleware('session')->middleware('csrf');
 };

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,6 +30,7 @@ return function (Router $router): void {
     // ==============================================================
 
     $router->middleware('session');
+    $router->middleware('csrf');
 
     // ==============================================================
     // Modern PSR-7 controllers (in app/Http/Controllers/)

--- a/src/Http/Csrf.php
+++ b/src/Http/Csrf.php
@@ -15,12 +15,7 @@ namespace TorrentPier\Http;
 use Illuminate\Support\Str;
 
 /**
- * Per-session CSRF token store.
- *
- * Tokens are bound to the active session identifier (real session_id for
- * authenticated users, session_ip for guests) and persisted in the bb_cache
- * store so they survive across page loads. Same identifier → same token until
- * it expires or session_id changes (login regenerates).
+ * Per-session CSRF token store keyed on session_id and persisted in bb_cache.
  */
 final class Csrf
 {
@@ -93,9 +88,9 @@ final class Csrf
         if (!$userdata) {
             return null;
         }
-        $identifier = ((int)($userdata['user_id'] ?? GUEST_UID) === GUEST_UID)
-            ? (string)($userdata['session_ip'] ?? '')
-            : (string)($userdata['session_id'] ?? '');
+        // Always key on session_id: User::session_create() issues one for guests too,
+        // so per-browser isolation works without sharing tokens behind NAT.
+        $identifier = (string)($userdata['session_id'] ?? '');
         if ($identifier === '') {
             return null;
         }

--- a/src/Http/Csrf.php
+++ b/src/Http/Csrf.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * TorrentPier – Bull-powered BitTorrent tracker engine
+ *
+ * @copyright Copyright (c) 2005-2025 TorrentPier (https://torrentpier.com)
+ * @link      https://github.com/torrentpier/torrentpier for the canonical source repository
+ * @license   https://github.com/torrentpier/torrentpier/blob/master/LICENSE MIT License
+ */
+
+declare(strict_types=1);
+
+namespace TorrentPier\Http;
+
+use Illuminate\Support\Str;
+
+/**
+ * Per-session CSRF token store.
+ *
+ * Tokens are bound to the active session identifier (real session_id for
+ * authenticated users, session_ip for guests) and persisted in the bb_cache
+ * store so they survive across page loads. Same identifier → same token until
+ * it expires or session_id changes (login regenerates).
+ */
+final class Csrf
+{
+    public const string FIELD = '_token';
+    public const string HEADER = 'X-CSRF-Token';
+    public const string CACHE_PREFIX = 'csrf_';
+    public const int TOKEN_LENGTH = 40;
+
+    /**
+     * Resolve the active token, generating one on first access for the session.
+     */
+    public static function token(): string
+    {
+        $key = self::cacheKey();
+        if ($key === null) {
+            return '';
+        }
+
+        $token = CACHE('bb_cache')->get($key);
+        if (\is_string($token) && \strlen($token) === self::TOKEN_LENGTH) {
+            return $token;
+        }
+
+        $token = Str::random(self::TOKEN_LENGTH);
+        CACHE('bb_cache')->set($key, $token, self::ttl());
+
+        return $token;
+    }
+
+    /**
+     * Compare a supplied token against the stored one in constant time.
+     */
+    public static function verify(?string $supplied): bool
+    {
+        if (!\is_string($supplied) || $supplied === '') {
+            return false;
+        }
+        $stored = self::token();
+        if ($stored === '') {
+            return false;
+        }
+        return hash_equals($stored, $supplied);
+    }
+
+    /**
+     * HTTP methods that mutate state and therefore require a token.
+     *
+     * @return list<string>
+     */
+    public static function protectedMethods(): array
+    {
+        return ['POST', 'PUT', 'PATCH', 'DELETE'];
+    }
+
+    /**
+     * Drop the stored token (used after logout / on session destruction).
+     */
+    public static function rotate(): void
+    {
+        $key = self::cacheKey();
+        if ($key !== null) {
+            CACHE('bb_cache')->rm($key);
+        }
+    }
+
+    private static function cacheKey(): ?string
+    {
+        $userdata = userdata() ?: null;
+        if (!$userdata) {
+            return null;
+        }
+        $identifier = ((int)($userdata['user_id'] ?? GUEST_UID) === GUEST_UID)
+            ? (string)($userdata['session_ip'] ?? '')
+            : (string)($userdata['session_id'] ?? '');
+        if ($identifier === '') {
+            return null;
+        }
+        return self::CACHE_PREFIX . $identifier;
+    }
+
+    private static function ttl(): int
+    {
+        $ttl = (int)config()->get('auth.sessions.user_duration');
+        return $ttl > 0 ? $ttl : 86400;
+    }
+}

--- a/src/Http/Csrf.php
+++ b/src/Http/Csrf.php
@@ -62,6 +62,7 @@ final class Csrf
         if ($stored === '') {
             return false;
         }
+
         return hash_equals($stored, $supplied);
     }
 
@@ -98,12 +99,14 @@ final class Csrf
         if ($identifier === '') {
             return null;
         }
+
         return self::CACHE_PREFIX . $identifier;
     }
 
     private static function ttl(): int
     {
         $ttl = (int)config()->get('auth.sessions.user_duration');
+
         return $ttl > 0 ? $ttl : 86400;
     }
 }

--- a/src/Template/TwigEnvironmentFactory.php
+++ b/src/Template/TwigEnvironmentFactory.php
@@ -131,6 +131,17 @@ class TwigEnvironmentFactory
         $twig->addFunction(new TwigFunction('profile_url', 'profile_url'));
         $twig->addFunction(new TwigFunction('render_flag', 'render_flag'));
 
+        // CSRF helpers
+        $twig->addFunction(new TwigFunction('csrf_token', \TorrentPier\Http\Csrf::token(...)));
+        $twig->addFunction(
+            new TwigFunction(
+                'csrf_field',
+                static fn (): string => '<input type="hidden" name="' . \TorrentPier\Http\Csrf::FIELD
+                    . '" value="' . htmlspecialchars(\TorrentPier\Http\Csrf::token(), ENT_QUOTES) . '">',
+                ['is_safe' => ['html']],
+            ),
+        );
+
         // SEO-friendly URL builder (use as: url.topic(id, title), url.forum(id, name), etc.)
         $twig->addGlobal('url', url());
 

--- a/tests/Integration/CsrfMiddlewareTest.php
+++ b/tests/Integration/CsrfMiddlewareTest.php
@@ -27,7 +27,7 @@ beforeEach(function () {
     // a live instance does not flap.
     $ctx = stream_context_create([
         'http' => ['timeout' => 2, 'ignore_errors' => true],
-        'ssl'  => ['verify_peer' => false, 'verify_peer_name' => false],
+        'ssl' => ['verify_peer' => false, 'verify_peer_name' => false],
     ]);
     $head = @file_get_contents($this->base . CSRF_LOGIN_PATH, false, $ctx);
     if ($head === false) {
@@ -90,7 +90,7 @@ function csrfRequest(
     $status = 0;
     foreach ($meta['wrapper_data'] ?? [] as $line) {
         if (preg_match('#^HTTP/[\d.]+\s+(\d+)#', $line, $m)) {
-            $status = (int) $m[1];
+            $status = (int)$m[1];
             continue;
         }
         if (str_contains($line, ':')) {

--- a/tests/Integration/CsrfMiddlewareTest.php
+++ b/tests/Integration/CsrfMiddlewareTest.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Integration tests for the CSRF middleware (PR #2420).
+ *
+ * Verifies end-to-end behaviour of `App\Http\Middleware\VerifyCsrfToken`
+ * against a running TorrentPier instance: token issuance via meta tag and
+ * hidden form field, 419 on missing/wrong token, 200 on correct `_token`
+ * body field or `X-CSRF-Token` header, token rotation after login/logout.
+ *
+ * Skips automatically when no HTTP base URL is configured. Set
+ *   TP_TEST_BASE_URL=https://tp.test/   (or another running instance)
+ * before running pest to enable.
+ */
+
+const CSRF_LOGIN_PATH = '/login';
+const CSRF_PROTECTED_POST_PATH = '/posting';
+const CSRF_TOKEN_LENGTH = 40;
+
+beforeEach(function () {
+    $base = getenv('TP_TEST_BASE_URL') ?: 'https://tp.test/';
+    $this->base = rtrim($base, '/');
+
+    // Probe — skip the suite when the host is unreachable so CI without
+    // a live instance does not flap.
+    $ctx = stream_context_create([
+        'http' => ['timeout' => 2, 'ignore_errors' => true],
+        'ssl'  => ['verify_peer' => false, 'verify_peer_name' => false],
+    ]);
+    $head = @file_get_contents($this->base . CSRF_LOGIN_PATH, false, $ctx);
+    if ($head === false) {
+        $this->markTestSkipped("TorrentPier instance not reachable at {$this->base}");
+    }
+
+    $this->cookieJar = [];
+});
+
+/**
+ * Issue a request with the in-memory cookie jar, returning [status, headers, body].
+ *
+ * @return array{0: int, 1: array<string, list<string>>, 2: string}
+ */
+function csrfRequest(
+    object $ctx,
+    string $method,
+    string $path,
+    array $body = [],
+    array $extraHeaders = [],
+): array {
+    $url = $ctx->base . $path;
+
+    $headers = ['Accept: text/html,application/json'];
+    foreach ($extraHeaders as $name => $value) {
+        $headers[] = $name . ': ' . $value;
+    }
+    if (!empty($ctx->cookieJar)) {
+        $cookieHeader = 'Cookie: ' . implode('; ', array_map(
+            fn ($name, $value) => $name . '=' . $value,
+            array_keys($ctx->cookieJar),
+            array_values($ctx->cookieJar),
+        ));
+        $headers[] = $cookieHeader;
+    }
+
+    $opts = [
+        'http' => [
+            'method' => $method,
+            'header' => implode("\r\n", $headers) . "\r\n",
+            'timeout' => 5,
+            'ignore_errors' => true,
+            'follow_location' => 0,
+        ],
+        'ssl' => ['verify_peer' => false, 'verify_peer_name' => false],
+    ];
+
+    if (in_array($method, ['POST', 'PUT', 'PATCH', 'DELETE'], true) && $body !== []) {
+        $opts['http']['header'] .= "Content-Type: application/x-www-form-urlencoded\r\n";
+        $opts['http']['content'] = http_build_query($body);
+    }
+
+    $stream = @fopen($url, 'r', false, stream_context_create($opts));
+    if ($stream === false) {
+        return [0, [], ''];
+    }
+
+    $meta = stream_get_meta_data($stream);
+    $responseHeaders = [];
+    $status = 0;
+    foreach ($meta['wrapper_data'] ?? [] as $line) {
+        if (preg_match('#^HTTP/[\d.]+\s+(\d+)#', $line, $m)) {
+            $status = (int) $m[1];
+            continue;
+        }
+        if (str_contains($line, ':')) {
+            [$name, $value] = explode(':', $line, 2);
+            $responseHeaders[strtolower(trim($name))][] = trim($value);
+        }
+    }
+
+    foreach ($responseHeaders['set-cookie'] ?? [] as $sc) {
+        if (preg_match('#^([^=]+)=([^;]*)#', $sc, $m)) {
+            $ctx->cookieJar[$m[1]] = $m[2];
+        }
+    }
+
+    $bodyContent = stream_get_contents($stream);
+    fclose($stream);
+
+    return [$status, $responseHeaders, $bodyContent ?: ''];
+}
+
+function extractMetaToken(string $html): ?string
+{
+    return preg_match('#<meta\s+name="csrf-token"\s+content="([^"]+)"#', $html, $m) ? $m[1] : null;
+}
+
+function extractFormToken(string $html): ?string
+{
+    return preg_match('#name="_token"\s+value="([^"]+)"#', $html, $m) ? $m[1] : null;
+}
+
+describe('CSRF middleware (live HTTP)', function () {
+    test('GET /login issues a 40-char token in both meta tag and hidden form field', function () {
+        [$status, , $body] = csrfRequest($this, 'GET', CSRF_LOGIN_PATH);
+        expect($status)->toBe(200);
+        $meta = extractMetaToken($body);
+        $form = extractFormToken($body);
+        expect($meta)
+            ->not->toBeNull()
+            ->and(strlen($meta))->toBe(CSRF_TOKEN_LENGTH);
+        expect($form)
+            ->not->toBeNull()
+            ->and($form)->toBe($meta);
+    });
+
+    test('POST without _token is rejected with 419 and a plain-text body', function () {
+        [$status, , $body] = csrfRequest($this, 'POST', CSRF_LOGIN_PATH, [
+            'login_username' => 'admin',
+            'login_password' => 'wrong',
+            'login' => '1',
+        ]);
+        expect($status)->toBe(419)
+            ->and(trim($body))->toBe('CSRF token mismatch.');
+    });
+
+    test('POST with a wrong _token is rejected with 419', function () {
+        [$status] = csrfRequest($this, 'POST', CSRF_LOGIN_PATH, [
+            '_token' => str_repeat('x', CSRF_TOKEN_LENGTH),
+            'login_username' => 'admin',
+            'login_password' => 'wrong',
+            'login' => '1',
+        ]);
+        expect($status)->toBe(419);
+    });
+
+    test('POST with a wrong X-CSRF-Token header is rejected with 419', function () {
+        [$status] = csrfRequest($this, 'POST', CSRF_PROTECTED_POST_PATH, [
+            'mode' => 'newtopic',
+            'f' => '1',
+        ], ['X-CSRF-Token' => str_repeat('y', CSRF_TOKEN_LENGTH)]);
+        expect($status)->toBe(419);
+    });
+
+    test('POST with the matching _token authenticates admin and rotates the token', function () {
+        [, , $loginPage] = csrfRequest($this, 'GET', CSRF_LOGIN_PATH);
+        $guestToken = extractMetaToken($loginPage);
+        expect($guestToken)->not->toBeNull();
+
+        [$status, $headers] = csrfRequest($this, 'POST', CSRF_LOGIN_PATH, [
+            '_token' => $guestToken,
+            'login_username' => 'admin',
+            'login_password' => 'admin',
+            'login' => '1',
+        ]);
+        expect($status)->toBe(302)
+            ->and($headers['location'][0] ?? null)->not->toBeNull();
+
+        // Visit a logged-in page; the new token should differ from the guest one.
+        [, , $home] = csrfRequest($this, 'GET', '/');
+        $adminToken = extractMetaToken($home);
+        expect($adminToken)
+            ->not->toBeNull()
+            ->and($adminToken)->not->toBe($guestToken);
+
+        // The stale guest token must now be rejected on a state-changing endpoint.
+        [$staleStatus] = csrfRequest($this, 'POST', CSRF_PROTECTED_POST_PATH, [
+            '_token' => $guestToken,
+            'mode' => 'newtopic',
+            'f' => '1',
+        ]);
+        expect($staleStatus)->toBe(419);
+    })->skip(
+        getenv('TP_TEST_ADMIN_PASSWORD') !== false && getenv('TP_TEST_ADMIN_PASSWORD') !== 'admin',
+        'Default admin/admin credentials required for this test',
+    );
+
+    test('POST with the matching token in the X-CSRF-Token header is accepted', function () {
+        [, , $page] = csrfRequest($this, 'GET', CSRF_LOGIN_PATH);
+        $token = extractMetaToken($page);
+        expect($token)->not->toBeNull();
+
+        [$status] = csrfRequest($this, 'POST', CSRF_PROTECTED_POST_PATH, [
+            'mode' => 'newtopic',
+            'f' => '1',
+        ], ['X-CSRF-Token' => $token]);
+
+        // /posting is auth-gated, so a guest gets a redirect/200 page rather than 419 — either
+        // way the request passed CSRF. We only assert that 419 did NOT happen.
+        expect($status)->not->toBe(419);
+    });
+});

--- a/tests/Unit/Http/CsrfTest.php
+++ b/tests/Unit/Http/CsrfTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use TorrentPier\Http\Csrf;
+
+describe('Csrf', function () {
+    test('exposes the canonical field and header names', function () {
+        expect(Csrf::FIELD)->toBe('_token');
+        expect(Csrf::HEADER)->toBe('X-CSRF-Token');
+    });
+
+    test('lists state-changing HTTP methods as protected', function () {
+        expect(Csrf::protectedMethods())->toBe(['POST', 'PUT', 'PATCH', 'DELETE']);
+    });
+
+    test('verify() rejects empty / non-string input', function () {
+        expect(Csrf::verify(''))->toBeFalse();
+        expect(Csrf::verify(null))->toBeFalse();
+    });
+
+    test('TOKEN_LENGTH is at least 32 characters', function () {
+        expect(Csrf::TOKEN_LENGTH)->toBeGreaterThanOrEqual(32);
+    });
+});

--- a/tests/Unit/Http/CsrfTest.php
+++ b/tests/Unit/Http/CsrfTest.php
@@ -22,4 +22,15 @@ describe('Csrf', function () {
     test('TOKEN_LENGTH is at least 32 characters', function () {
         expect(Csrf::TOKEN_LENGTH)->toBeGreaterThanOrEqual(32);
     });
+
+    test('CACHE_PREFIX is "csrf_" so keys cannot collide with other bb_cache namespaces', function () {
+        expect(Csrf::CACHE_PREFIX)->toBe('csrf_');
+    });
+
+    test('protectedMethods() does not include safe HTTP methods', function () {
+        $protected = Csrf::protectedMethods();
+        expect($protected)->not->toContain('GET')
+            ->not->toContain('HEAD')
+            ->not->toContain('OPTIONS');
+    });
 });


### PR DESCRIPTION
## Summary

Follow-up to #2418. Adds the CSRF token check that was deliberately deferred there.

Until now, every public POST handler (login, posting, privmsg, profile, modcp, group, 2FA, PM, search) accepted form submissions with no token verification — `SameSite=Lax` cookies were the only thing between them and a malicious cross-site form, and that is a mitigation, not a substitute.

### Infrastructure (`security: add CSRF token middleware and helpers`)
- `TorrentPier\Http\Csrf` (`src/Http/Csrf.php`) — per-session token store keyed on `session_id` (issued for guests too by `User::session_create()`, so per-browser isolation works without sharing tokens behind NAT), persisted in `bb_cache` for `auth.sessions.user_duration`. Comparison is `hash_equals`.
- `App\Http\Middleware\VerifyCsrfToken` — PSR-7 middleware. Reads `_token` from the parsed body and falls back to the `X-CSRF-Token` header for AJAX. Rejects with HTTP 419 on mismatch; `GET`/`HEAD`/`OPTIONS` pass through but warm the token so the next POST has something to send.
- `'csrf'` alias wired in `bootstrap/app.php` and applied as a global middleware on the shared `Router` instance from `routes/web.php`. Because `routes/web.php`, `routes/api.php` and `routes/admin.php` all register against the same router, **the `csrf` middleware covers web, api and admin routes**. Tracker (`routes/tracker.php`) is loaded into a separate scope and is intentionally not protected — BT clients have no session and no token to send.
- `csrf_token()` and `csrf_field()` exposed as Twig functions; `csrf_field` is marked `is_safe => html` so it works regardless of autoescape.

### Plumbing (`security: emit CSRF tokens in form templates and AJAX requests`)
- `<meta name="csrf-token">` rendered in `page_header.twig` so every page (including 419) carries the active token.
- `main.js`: on `document.ready` reads the meta, sets up `$.ajaxSetup.beforeSend` to attach `X-CSRF-Token` to every same-origin state-changing XHR, exposes the token to the legacy `Ajax.prototype.form_token` field, and injects a hidden `_token` into any `<form method="post">` that the templates didn't render `csrf_field()` into yet — keeps existing JS-driven flows working without a per-template sweep.
- `csrf_field()` added explicitly in the no-JS-critical templates: `login.twig`, `login_2fa.twig` (all three forms), `usercp_register.twig`, `usercp_sendpasswd.twig`, `posting.twig`, `privmsgs_read.twig`, `modcp.twig`, `modcp_split.twig`, `usercp_email.twig`, `usercp_twofactor_{setup,disable,regenerate}.twig`, `group_edit.twig`.

## Out of scope (intentional)
- **Admin `.tpl` templates**: legacy admin templates under `resources/views/admin/*.tpl` do not yet emit `csrf_field()`. POST forms there are still covered by the global middleware (419 on mismatch) and by the JS submit-time auto-injection in `main.js`, so they keep working in practice. Sweeping the `.tpl` files to render the field server-side is a no-risk follow-up.
- **Per-template csrf_field() everywhere**: minor public templates (search, viewforum mod actions, viewtopic poll vote, usercp_topic_watch, usercp_bonus, group.twig, posting_tpl, etc.) still rely on the JS auto-injection. Adding `csrf_field()` to them is a no-risk follow-up.
- **Legacy `tokenized` form class**: classes are kept; the auto-injection is additive.

## Test plan
- [x] `vendor/bin/pest` — 1546 passed (4 new in `tests/Unit/Http/CsrfTest.php`), 30 skipped, 0 failed
- [x] PHP `-l` syntax check on every modified PHP file
- [x] Manual: `GET /login` returns the form with `<meta name="csrf-token">` and a hidden `_token`. POST with the matching token logs in. POST with a stale/blank token returns 419
- [x] Manual: `POST /api/ajax/post-mod-comment` from the JS UI sends `X-CSRF-Token` header and is accepted; without/with a wrong token the server returns 419
- [x] Manual: stale guest token after login → 419; admin token reused after logout → 419 (rotation works)
- [x] Manual: `POST /admin/` without `_token` → 419 (covered by global middleware via shared router)
- [x] Manual: `GET /bt/announce.php` is unaffected (tracker route group is in a separate scope)
- [ ] Manual: register a new user via the form (no JS) — must succeed
- [ ] Manual: open two tabs on the same session, log out in tab A, then submit a form in tab B — token rotation will make it fail (open question for review: do we want a JS handler that catches 419 and prompts a reload?)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added comprehensive CSRF (Cross-Site Request Forgery) protection across the application. All state-changing requests—including form submissions and AJAX calls—now require and verify CSRF tokens to prevent unauthorized actions. Protection is automatically applied to user registration, login, two-factor authentication, private messages, email changes, and moderation forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
