### PR TITLE
fix(image): complete Intervention Image v4 API migration

### DIFF
--- a/src/Image/ImageService.php
+++ b/src/Image/ImageService.php
@@ -38,7 +38,7 @@ class ImageService
      */
     public static function read(string $path): ImageInterface
     {
-        return self::getManager()->read($path);
+        return self::getManager()->decodePath($path);
     }
 
     /**
@@ -46,6 +46,6 @@ class ImageService
      */
     public static function create(int $width, int $height): ImageInterface
     {
-        return self::getManager()->create($width, $height);
+        return self::getManager()->createImage($width, $height);
     }
 }

--- a/src/Legacy/Common/Upload.php
+++ b/src/Legacy/Common/Upload.php
@@ -147,6 +147,7 @@ class Upload
 
                     ImageService::read($this->file['tmp_name'])
                         ->scaleDown($maxWidth, $maxHeight)
+                        ->encodeUsingFileExtension($this->file_ext)
                         ->save($this->file['tmp_name']);
 
                     // Update file size after resize
@@ -250,7 +251,7 @@ class Upload
         clearstatcache(true, $path);
         while (files()->size($path) > $maxSize && $quality > $minQuality) {
             $quality = max($quality - 10, $minQuality);
-            ImageService::read($path)->save($path, quality: $quality);
+            ImageService::read($path)->encodeUsingFileExtension($this->file_ext, quality: $quality)->save($path);
             clearstatcache(true, $path);
         }
     }


### PR DESCRIPTION
PR #2383 bumped intervention/image to ^4.0 without updating call sites:

- `ImageManager::read()` / `create()` were renamed to `decodePath()` / `createImage()` in v4 — updated `ImageService` accordingly.
- `Image::save($path)` derives the encoder from the path extension and throws `NotSupportedException` / `InvalidArgumentException` (neither is an `EncoderException`, so `save()`'s own fallback misses them) for tmp paths like `phpXXXX.tmp` on Windows or extension-less tmp files on Linux. Encode explicitly via `encodeUsingFileExtension(\$this->file_ext)` before saving so the format is taken from the already-detected image type.

The exception was masked by `Upload::init`'s broad catch as `UPLOAD_ERROR_DIMENSIONS` ("Image dimensions exceed the maximum allowable NxN pixels"), surfacing on avatar uploads — regular file uploads and the MonsterID flow alike.