### PR TITLE
fix(cache): bull cache:clear now actually clears datastore

### DIFF
--- a/app/Console/Commands/Cache/CacheClearCommand.php
+++ b/app/Console/Commands/Cache/CacheClearCommand.php
@@ -126,18 +126,20 @@ class CacheClearCommand extends Command
      */
     private function clearSystemCache(): void
     {
-        // Use injected config or fall back to constant
-        $cacheDir = \defined('CACHE_DIR') ? CACHE_DIR : $this->config->get('cache_dir');
-
-        if (files()->isDirectory($cacheDir)) {
-            FileSystemHelper::clearDirectory($cacheDir);
+        // Legacy path (storage/framework/cache); active caches live under cache.db_dir.
+        $legacyCacheDir = \defined('CACHE_DIR') ? CACHE_DIR : $this->config->get('cache_dir');
+        if ($legacyCacheDir && files()->isDirectory($legacyCacheDir)) {
+            FileSystemHelper::clearDirectory($legacyCacheDir);
         }
 
-        // Clear runtime cache using injected cache system
+        $activeCacheDir = $this->cacheSystem->getCacheBaseDir();
+        if ($activeCacheDir && files()->isDirectory($activeCacheDir)) {
+            FileSystemHelper::clearDirectory($activeCacheDir);
+        }
+
         try {
-            $this->cacheSystem->get_cache_obj('bb_cache')?->clean();
+            $this->cacheSystem->clearAll();
         } catch (Throwable) {
-            // Ignore if the cache is not available
         }
     }
 

--- a/config/cache.php
+++ b/config/cache.php
@@ -24,6 +24,8 @@ return [
         ],
     ],
     'prefix' => 'tp_',
+    // Single cache root for CLI and PHP-FPM; otherwise sys_get_temp_dir() diverges between them.
+    'db_dir' => CACHE_DIR . '/filecache/',
     'engines' => [
         'bb_cache' => ['file'],
         'bb_config' => ['file'],

--- a/src/Cache/UnifiedCacheSystem.php
+++ b/src/Cache/UnifiedCacheSystem.php
@@ -188,6 +188,14 @@ class UnifiedCacheSystem
     }
 
     /**
+     * Base directory used by file-backed namespaces and datastore.
+     */
+    public function getCacheBaseDir(): string
+    {
+        return rtrim($this->cfg['db_dir'] ?? sys_get_temp_dir() . '/cache/', '/');
+    }
+
+    /**
      * Clear all caches
      */
     public function clearAll(): void


### PR DESCRIPTION
## Summary
- \`bull cache:clear\` silently missed the datastore and most other namespaces because it cleared \`storage/framework/cache\` while \`UnifiedCacheSystem\` writes under \`sys_get_temp_dir()/cache/\`, and only flushed the \`bb_cache\` namespace in process.
- \`sys_get_temp_dir()\` resolves to different paths in CLI and PHP-FPM (on macOS, \`/private/var/folders/.../T/cache/\` vs \`/var/tmp/cache/\`), so even when the legacy path matched, the two processes saw different caches.
- Pinned \`cache.db_dir\` to \`CACHE_DIR/filecache/\` so CLI and FPM share a single root, exposed \`UnifiedCacheSystem::getCacheBaseDir()\`, and rewired \`CacheClearCommand\` to clear the active root and call \`clearAll()\`.

Symptom that prompted this: an admin self-ban was written into the datastore by the FPM worker; running \`bull cache:clear\` left the stale \`ban_list\` cache in \`/var/tmp/cache/datastore/\` untouched and the admin stayed locked out.

## Test plan
- [ ] \`php bull cache:clear -f\` removes everything under the active cache root used by FPM
- [ ] After a fresh request, file-backed namespaces (bb_cache, datastore, session_cache, …) land under \`storage/framework/cache/filecache/\` instead of \`/var/tmp/cache/\`
- [ ] Existing setups that rely on the old \`sys_get_temp_dir()\` location are unaffected (orphaned files there are simply ignored, regenerate on next access)

@codex review
@claude review

🤖 Generated with [Claude Code](https://claude.com/claude-code)