### PR TITLE
fix(admin): frameset 404s when /admin opened without trailing slash

### DIFF
--- a/resources/views/admin/index.tpl
+++ b/resources/views/admin/index.tpl
@@ -9,8 +9,8 @@
 </head>
 
 <frameset cols="220,*" rows="*" border="1" framespacing="1" frameborder="yes">
-  <frame src="index.php?pane=left" name="nav" marginwidth="0" marginheight="0" scrolling="auto">
-  <frame src="index.php?pane=right" name="main" marginwidth="0" marginheight="0" scrolling="auto">
+  <frame src="/admin/index.php?pane=left" name="nav" marginwidth="0" marginheight="0" scrolling="auto">
+  <frame src="/admin/index.php?pane=right" name="main" marginwidth="0" marginheight="0" scrolling="auto">
 </frameset>
 </html>
 <!--========================================================================-->


### PR DESCRIPTION
## Summary
- Opening \`https://example/admin\` (no trailing slash) returned the frameset HTML, but each frame's relative \`src=\"index.php?pane=…\"\` resolved against \`/\`, sending the browser to \`/index.php?pane=left\` and \`/index.php?pane=right\` — both 404.
- Switched the two frame sources to absolute \`/admin/index.php?pane=…\` so the URL resolves consistently regardless of how \`/admin\` is requested (the route already accepts \`\`, \`/\`, and \`/index.php\`).

## Test plan
- [ ] \`https://example/admin\` renders both panes (left nav, right main) without 404
- [ ] \`https://example/admin/\` still works as before
- [ ] \`https://example/admin/index.php\` still works as before
- [ ] Inner nav links (relative \`admin_*.php\`) still target the \`main\` frame correctly

@codex review
@claude review

🤖 Generated with [Claude Code](https://claude.com/claude-code)