### PR TITLE
fix(admin): unban form crashes on submit

### DIFF
--- a/app/Http/Controllers/Admin/admin_user_ban.php
+++ b/app/Http/Controllers/Admin/admin_user_ban.php
@@ -36,11 +36,10 @@ if ($submit) {
     }
 
     // Unban action
-    $where_sql = '';
+    $user_list = request()->getArray('unban_user');
 
-    if (!empty(request()->post->get('unban_user'))) {
-        $user_list = request()->getArray('unban_user');
-
+    if (!empty($user_list)) {
+        $where_sql = '';
         for ($i = 0, $iMax = count($user_list); $i < $iMax; $i++) {
             if ($user_list[$i] != -1) {
                 $where_sql .= (($where_sql != '') ? ', ' : '') . (int)$user_list[$i];

--- a/src/Sitemap.php
+++ b/src/Sitemap.php
@@ -72,7 +72,7 @@ class Sitemap
 
         while ($row = DB()->sql_fetchrow($sql)) {
             $forumUrls[] = [
-                'url' => \url()->forum((int)$row['forum_id'], $row['forum_name']),
+                'url' => url()->forum((int)$row['forum_id'], $row['forum_name']),
                 'time' => $row['last_topic_time'],
             ];
         }
@@ -96,7 +96,7 @@ class Sitemap
 
         while ($row = DB()->sql_fetchrow($sql)) {
             $topicUrls[] = [
-                'url' => \url()->topic((int)$row['topic_id'], $row['topic_title']),
+                'url' => url()->topic((int)$row['topic_id'], $row['topic_title']),
                 'time' => $row['topic_last_post_time'],
             ];
         }


### PR DESCRIPTION
## Summary
- The unban branch in \`admin_user_ban.php\` called \`request()->post->get('unban_user')\` directly. \`unban_user\` is a multi-select sending \`unban_user[]\`, so Symfony's \`InputBag::get\` throws \`BadRequestException: Input value \"unban_user\" contains a non-scalar value.\`, and any submit that selects something to unban renders the global 500 page.
- Read the array with the wrapper's \`getArray()\` first and \`!empty\`-check that. The unban branch only runs when at least one option was actually selected.

## Test plan
- [ ] Selecting one banned user and submitting removes that ban
- [ ] Selecting multiple banned users in the multi-select removes all of them in one go
- [ ] Submitting with nothing selected is a no-op (and doesn't 500)
- [ ] Ban + unban in the same submit still works
- [ ] No PHP error / no \`BadRequestException\` in \`storage/logs/php_whoops.log\` for the unban path

@codex review
@claude review

🤖 Generated with [Claude Code](https://claude.com/claude-code)