### PR TITLE
fix(admin): prevent 500 errors in admin_forum_prune and admin_forumauth_list

### DIFF
--- a/app/Http/Controllers/Admin/admin_forum_prune.php
+++ b/app/Http/Controllers/Admin/admin_forum_prune.php
@@ -19,10 +19,10 @@ $pruned_total = 0;
 $prune_performed = false;
 
 if (request()->has('submit')) {
-    if (!$var = request()->get('f') || !$f_selected = get_id_ary($var)) {
+    if (!($var = request()->get('f')) || !($f_selected = get_id_ary($var))) {
         bb_die(__('SELECT_FORUM'));
     }
-    if (!$var = request()->get('prunedays') || !$prunedays = abs((int)$var)) {
+    if (!($var = request()->get('prunedays')) || !($prunedays = abs((int)$var))) {
         bb_die(__('NOT_DAYS'));
     }
 

--- a/app/Http/Controllers/Admin/admin_forumauth_list.php
+++ b/app/Http/Controllers/Admin/admin_forumauth_list.php
@@ -58,11 +58,13 @@ foreach ($forum_auth_fields as $auth_type) {
 $forum_auth_levels = ['ALL', 'REG', 'PRIVATE', 'MOD', 'ADMIN'];
 $forum_auth_const = [AUTH_ALL, AUTH_REG, AUTH_ACL, AUTH_MOD, AUTH_ADMIN];
 
+$forum_id = 0;
+$cat_id = 0;
+
 if (request()->query->has(POST_FORUM_URL) || request()->post->has(POST_FORUM_URL)) {
     $forum_id = request()->getInt(POST_FORUM_URL, 0);
     $forum_sql = "AND forum_id = {$forum_id}";
 } else {
-    unset($forum_id);
     $forum_sql = '';
 }
 
@@ -70,7 +72,6 @@ if (request()->query->has(POST_CAT_URL) || request()->post->has(POST_CAT_URL)) {
     $cat_id = request()->getInt(POST_CAT_URL, 0);
     $cat_sql = "AND c.cat_id = {$cat_id}";
 } else {
-    unset($cat_id);
     $cat_sql = '';
 }
 
@@ -258,6 +259,10 @@ if (empty($forum_id) && empty($cat_id)) {
     }
 
     $category_rows = DB()->sql_fetchrowset($result);
+
+    if (empty($category_rows)) {
+        bb_die(sprintf(__('CLICK_RETURN_FORUMAUTH'), '<a href="admin_forumauth_list.php">', '</a>'));
+    }
 
     $cat_id = reset($category_rows)['cat_id'];
     $cat_name = reset($category_rows)['cat_title'];

--- a/src/Sitemap.php
+++ b/src/Sitemap.php
@@ -72,7 +72,7 @@ class Sitemap
 
         while ($row = DB()->sql_fetchrow($sql)) {
             $forumUrls[] = [
-                'url' => \url()->forum((int)$row['forum_id'], $row['forum_name']),
+                'url' => url()->forum((int)$row['forum_id'], $row['forum_name']),
                 'time' => $row['last_topic_time'],
             ];
         }
@@ -96,7 +96,7 @@ class Sitemap
 
         while ($row = DB()->sql_fetchrow($sql)) {
             $topicUrls[] = [
-                'url' => \url()->topic((int)$row['topic_id'], $row['topic_title']),
+                'url' => url()->topic((int)$row['topic_id'], $row['topic_title']),
                 'time' => $row['topic_last_post_time'],
             ];
         }


### PR DESCRIPTION
## Summary

Two crash fixes found while manually QAing the admin section
(`/admin/admin_forumauth_list.php`, `/admin/admin_forum_prune.php`,
`/admin/admin_board.php?mode=config`):

### `admin_forum_prune.php` — operator precedence bug

The guards at the top of the submit handler were written as

```php
if (!$var = request()->get('f') || !$f_selected = get_id_ary($var)) {
    bb_die(__('SELECT_FORUM'));
}
if (!$var = request()->get('prunedays') || !$prunedays = abs((int)$var)) {
    bb_die(__('NOT_DAYS'));
}
```

Because `||` binds tighter than `=`, PHP parses this as
`$var = (request()->get(...) || !$f_selected = get_id_ary($var))`,
which means `$f_selected` and `$prunedays` are **never assigned** when
the field is non-empty (the right side is short-circuited away).
Every submit then died at the next line with
`Undefined variable $prunedays` → HTTP 500. With nothing posted the
*right* side ran first and used the not-yet-assigned `$var`, also
500-ing with `Undefined variable $var`.

Adding parentheses around the assignments fixes both cases so the
page actually validates input as intended.

### `admin_forumauth_list.php` — crash on missing cat / forum id

- `?c=<non-existent>` reached `reset($category_rows)['cat_id']` with an
  empty result set, blowing up with
  `Trying to access array offset on false` (500).
- `?f=<id>` (forum-only) entered the same branch without `$cat_id` ever
  being defined, building the SQL `WHERE c.cat_id = ` and producing a
  warning + 500.

Now `$forum_id`/`$cat_id` default to `0` instead of being `unset()`, and
an empty `$category_rows` returns the standard "Click Here to return to
Forum Permissions" message instead of a fatal error.

## Test plan

- [x] `GET /admin/admin_forum_prune.php` — loads
- [x] Submit empty form → "Select forum" message (previously: 500)
- [x] Submit forum without `prunedays` → "Prune days not selected"
- [x] Submit forum + `prunedays=99999` → "No topics or posts met your search criteria" (previously: 500)
- [x] `GET /admin/admin_forumauth_list.php` — full overview renders
- [x] `GET /admin/admin_forumauth_list.php?c=1` — per-category edit form renders
- [x] `GET /admin/admin_forumauth_list.php?c=99999` — graceful "return" message (previously: 500)
- [x] `GET /admin/admin_forumauth_list.php?f=99999` — graceful "return" message (previously: 500)
- [x] Submit forms to confirm DB updates still apply correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)