### PR TITLE
fix(admin): validate rebuild_search inputs and stop SQL/status errors

### DIFF
--- a/app/Http/Controllers/Admin/admin_rebuild_search.php
+++ b/app/Http/Controllers/Admin/admin_rebuild_search.php
@@ -49,7 +49,7 @@ if (request()->has('cancel_button')) {
 		");
     }
 
-    bb_die(sprintf(__('REBUILD_SEARCH_ABORTED'), $last_session_data['end_post_id']) . '<br /><br />' . sprintf(__('CLICK_RETURN_REBUILD_SEARCH'), '<a href="admin_rebuild_search.php">', '</a>'));
+    bb_die(sprintf(__('REBUILD_SEARCH_ABORTED'), $last_session_data['end_post_id']) . '<br /><br />' . sprintf(__('CLICK_RETURN_REBUILD_SEARCH'), '<a href="admin_rebuild_search.php">', '</a>'), 200);
 }
 
 // from which post to start processing
@@ -62,7 +62,9 @@ $total_posts = get_total_posts();
 $clear_search = request()->getInt('clear_search');
 
 // get the number of total/session posts already processed
-$total_posts_processed = ($start != 0) ? get_total_posts('before', $last_session_data['end_post_id']) : 0;
+$total_posts_processed = !empty($last_session_data['end_post_id'])
+    ? get_total_posts('before', $last_session_data['end_post_id'])
+    : 0;
 $session_posts_processed = ($mode == 'refresh') ? get_processed_posts('session', $last_session_data) : 0;
 
 // find how many posts aren't processed
@@ -71,6 +73,8 @@ $total_posts_processing = $total_posts - $total_posts_processed;
 // how many posts to process in this session
 $session_posts_processing = request()->has('session_posts_processing') ? request()->getInt('session_posts_processing') : null;
 if ($session_posts_processing !== null) {
+    // reject negative input that would break downstream math/SQL
+    $session_posts_processing = max(0, $session_posts_processing);
     if ($mode == 'submit') {
         // check if we passed over total_posts just after submitting
         if ($session_posts_processing + $total_posts_processed > $total_posts) {
@@ -84,8 +88,8 @@ if ($session_posts_processing !== null) {
     $session_posts_processing = (!$total_posts_processing) ? $total_posts : $total_posts_processing;
 }
 
-// how many posts to process per cycle
-$post_limit = request()->getInt('post_limit', $def_post_limit);
+// how many posts to process per cycle (clamp to avoid negative LIMIT in SQL)
+$post_limit = max(0, request()->getInt('post_limit', $def_post_limit));
 
 // correct the post_limit when we pass over it
 if ($session_posts_processed + $post_limit > $session_posts_processing) {
@@ -94,7 +98,7 @@ if ($session_posts_processed + $post_limit > $session_posts_processing) {
 
 // how much time to wait per cycle
 if (request()->has('time_limit')) {
-    $time_limit = request()->getInt('time_limit');
+    $time_limit = max(0, request()->getInt('time_limit'));
 } else {
     $time_limit = $def_time_limit;
     $time_limit_explain = __('TIME_LIMIT_EXPLAIN');
@@ -118,12 +122,12 @@ if (request()->has('time_limit')) {
 }
 
 // how much time to wait between page refreshes
-$refresh_rate = request()->getInt('refresh_rate', $def_refresh_rate);
+$refresh_rate = max(0, request()->getInt('refresh_rate', $def_refresh_rate));
 
-// check if the user gave wrong input
+// check if the user gave wrong input — every value must be strictly positive
 if ($mode == 'submit') {
-    if (($session_posts_processing || $post_limit || $refresh_rate || $time_limit) <= 0) {
-        bb_die(__('WRONG_INPUT') . '<br /><br />' . sprintf(__('CLICK_RETURN_REBUILD_SEARCH'), '<a href="admin_rebuild_search.php">', '</a>'));
+    if ($session_posts_processing <= 0 || $post_limit <= 0 || $refresh_rate <= 0 || $time_limit <= 0) {
+        bb_die(__('WRONG_INPUT') . '<br /><br />' . sprintf(__('CLICK_RETURN_REBUILD_SEARCH'), '<a href="admin_rebuild_search.php">', '</a>'), 400);
     }
 }
 

--- a/src/Sitemap.php
+++ b/src/Sitemap.php
@@ -72,7 +72,7 @@ class Sitemap
 
         while ($row = DB()->sql_fetchrow($sql)) {
             $forumUrls[] = [
-                'url' => \url()->forum((int)$row['forum_id'], $row['forum_name']),
+                'url' => url()->forum((int)$row['forum_id'], $row['forum_name']),
                 'time' => $row['last_topic_time'],
             ];
         }
@@ -96,7 +96,7 @@ class Sitemap
 
         while ($row = DB()->sql_fetchrow($sql)) {
             $topicUrls[] = [
-                'url' => \url()->topic((int)$row['topic_id'], $row['topic_title']),
+                'url' => url()->topic((int)$row['topic_id'], $row['topic_title']),
                 'time' => $row['topic_last_post_time'],
             ];
         }


### PR DESCRIPTION
## Summary

QA-pass over `admin_rebuild_search.php` surfaced four bugs:

- `post_limit=-50` reached SQL as `LIMIT -50` → HTTP 500 / Database Error.
- Submit-time validation `($a || $b || $c || $d) <= 0` collapses to `(bool) <= 0` and is `false` whenever any single field is non-zero. `session_posts_processing=0` (or any single-zero field) bypassed WRONG_INPUT entirely and rendered a no-op rebuild with ranges like *"Total from 963 to 962 (out of total 962)"*.
- After clicking Cancel the form re-rendered `(0 processed posts)` because `$total_posts_processed` was gated on `$start != 0`, which is `0` on a bare GET — even when an aborted session with a non-zero `end_post_id` was present.
- The successful Cancel page (`REBUILD_SEARCH_ABORTED`) itself returned **HTTP 500** because `bb_die()` defaults to 500 and the caller passed no status.

## Changes

| Bug | Fix |
| --- | --- |
| Negative `post_limit` → SQL syntax error | `max(0, …)` clamp around every numeric `request()->getInt()` (`post_limit`, `time_limit`, `refresh_rate`, `session_posts_processing`) so a hand-crafted `mode=refresh` URL cannot reintroduce a negative `LIMIT`. |
| Broken WRONG_INPUT guard | Replaced with per-field strict-positive checks, emits `HTTP 400` instead of 500. |
| `(0 processed posts)` after Cancel | `$total_posts_processed` is now derived from `$last_session_data['end_post_id']` (when present), not from `$start`. |
| HTTP 500 on successful Cancel page | `bb_die(..., 200)` for `REBUILD_SEARCH_ABORTED`. |

## Side-effect to note for reviewers

The `$total_posts_processed` change is not purely cosmetic — it also flips the default of the "Number of posts" field after Cancel from the total (`962`) to the remaining count (e.g. `162`), which matches the pre-selected "continue from where you last stopped" combobox option. `swap_values()` in the template still swaps both fields when the user picks "start from beginning", so the form stays internally consistent.

## Out of scope

- A CSRF `HTTP 419` was occasionally observed on the post-completion `Finished` button, but could not be reproduced cleanly enough to root-cause. `Csrf::rotate()` has no callsites and the token TTL is 14 days, so the failure mode is non-obvious — tracking separately.
- `bb_die()` returning 500 for *other* admin success/info pages is a wider refactor and is not touched here.

## Test plan

- [x] Syntax check (`php -l`) passes
- [x] Manual: `post_limit=-50` no longer produces a DB error; submit returns the WRONG_INPUT page (HTTP 400 after fix)
- [x] Manual: `session_posts_processing=0` now hits WRONG_INPUT instead of rendering an empty progress page
- [x] Manual: Cancel page returns HTTP 200 and the follow-up form shows the real processed count and remaining-posts default
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)