### PR TITLE
fix(admin): correct user-search popup URL and validate moderator lookup

### DIFF
--- a/app/Http/Controllers/Admin/admin_groups.php
+++ b/app/Http/Controllers/Admin/admin_groups.php
@@ -57,7 +57,7 @@ if (request()->post->get('edit') || request()->post->get('new')) {
         'GROUP_DESCRIPTION' => stripslashes(htmlspecialchars($group_info['group_description'])),
         'GROUP_MODERATOR' => htmlspecialchars($group_info['group_mod_name'], ENT_QUOTES),
         'T_GROUP_EDIT_DELETE' => ($mode == 'newgroup') ? __('CREATE_NEW_GROUP') : __('EDIT_GROUP'),
-        'U_SEARCH_USER' => BB_ROOT . 'search.php?mode=searchuser',
+        'U_SEARCH_USER' => '/search?mode=searchuser',
         'S_GROUP_OPEN_TYPE' => GROUP_OPEN,
         'S_GROUP_CLOSED_TYPE' => GROUP_CLOSED,
         'S_GROUP_HIDDEN_TYPE' => GROUP_HIDDEN,
@@ -95,9 +95,10 @@ if (request()->post->get('edit') || request()->post->get('new')) {
         }
         $this_userdata = get_userdata($group_moderator, true);
 
-        if (!$group_moderator = $this_userdata['user_id']) {
+        if (!$this_userdata || empty($this_userdata['user_id'])) {
             bb_die(__('NO_GROUP_MODERATOR'));
         }
+        $group_moderator = $this_userdata['user_id'];
 
         $sql_ary = [
             'group_type' => (int)$group_type,

--- a/app/Http/Controllers/Admin/admin_ug_auth.php
+++ b/app/Http/Controllers/Admin/admin_ug_auth.php
@@ -419,7 +419,7 @@ if ($mode == 'user' && (request()->post->get('username') || $user_id)) {
     if ($mode == 'user') {
         template()->assign_vars([
             'TPL_SELECT_USER' => true,
-            'U_SEARCH_USER' => BB_ROOT . 'search.php?mode=searchuser',
+            'U_SEARCH_USER' => '/search?mode=searchuser',
         ]);
     } else {
         template()->assign_vars([

--- a/app/Http/Controllers/Admin/admin_user_ban.php
+++ b/app/Http/Controllers/Admin/admin_user_ban.php
@@ -71,7 +71,7 @@ if ($submit) {
     $select_userlist = '<select name="unban_user[]" multiple size="5">' . $select_userlist . '</select>';
 
     template()->assign_vars([
-        'U_SEARCH_USER' => './../search.php?mode=searchuser',
+        'U_SEARCH_USER' => '/search?mode=searchuser',
         'S_UNBAN_USERLIST_SELECT' => $select_userlist,
         'S_BAN_ACTION' => 'admin_user_ban.php',
     ]);

--- a/app/Http/Controllers/Admin/admin_user_search.php
+++ b/app/Http/Controllers/Admin/admin_user_search.php
@@ -98,7 +98,7 @@ if (!request()->get('dosearch')) {
         'FORUMS_LIST' => $forums_list,
         'LASTVISITED_LIST' => $lastvisited_list,
 
-        'U_SEARCH_USER' => BB_ROOT . 'search.php?mode=searchuser',
+        'U_SEARCH_USER' => '/search?mode=searchuser',
         'S_SEARCH_ACTION' => 'admin_user_search.php',
     ]);
 } else {

--- a/src/Sitemap.php
+++ b/src/Sitemap.php
@@ -72,7 +72,7 @@ class Sitemap
 
         while ($row = DB()->sql_fetchrow($sql)) {
             $forumUrls[] = [
-                'url' => \url()->forum((int)$row['forum_id'], $row['forum_name']),
+                'url' => url()->forum((int)$row['forum_id'], $row['forum_name']),
                 'time' => $row['last_topic_time'],
             ];
         }
@@ -96,7 +96,7 @@ class Sitemap
 
         while ($row = DB()->sql_fetchrow($sql)) {
             $topicUrls[] = [
-                'url' => \url()->topic((int)$row['topic_id'], $row['topic_title']),
+                'url' => url()->topic((int)$row['topic_id'], $row['topic_title']),
                 'time' => $row['topic_last_post_time'],
             ];
         }


### PR DESCRIPTION
## Summary
- **Find a username popup → 404**: the inline `onclick` opened `./search.php?mode=searchuser`, which resolves to `/admin/search.php` when the popup is launched from an admin page and yields _Page not found_ (only the SEO-friendly `/search` route exists). Switched four admin controllers to the absolute `/search?mode=searchuser` so the popup works regardless of where it is opened from.
- **500 on unknown moderator name**: creating or editing a group with a non-existent username triggered `Trying to access array offset on false` in `admin_groups.php:98` because `get_userdata()` returns `false` for missing users and the code dereferenced the result before checking it. Validate the array first, then assign.

## Reproduction (before fix)
1. Admin → User groups → pick any group → _Find a username_. New tab opens `/admin/search.php?mode=searchuser` showing _Page not found_. Same happens from _Permissions (user)_, _User Search_, and _User Ban_.
2. Admin → User groups → _Create new group_, fill name/description, set _Group Moderator_ to a non-existent username, _Submit_ → 500 page (`Sorry, something went wrong…`), `php_whoops.log` shows `Trying to access array offset on false in admin_groups.php on line 98`.

## Test plan
- [ ] Open any admin page that has the _Find a username_ button (User groups → Look up, Permissions → user mode, User Ban, User Search). Click the button — popup loads the search form, no 404.
- [ ] Admin → User groups → _Create new group_ with `username = nope_xyz` → friendly `NO_GROUP_MODERATOR` message instead of 500.
- [ ] Admin → User groups → edit existing group, submit `username = nope_xyz` → same friendly message.
- [ ] Create a real group with a valid moderator and edit it (rename, change moderator, toggle release-group flag) — still works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)