### PR TITLE
fix(admin): return 404 instead of 500 on missing forum in admin_forumauth

### DIFF
--- a/app/Http/Controllers/Admin/admin_forumauth.php
+++ b/app/Http/Controllers/Admin/admin_forumauth.php
@@ -141,6 +141,10 @@ if (empty($forum_id)) {
     ]);
 } else {
     // Output the authorisation details if an id was specified
+    if (empty($forum_rows)) {
+        bb_die(__('FORUM_NOT_EXIST'), 404);
+    }
+
     $forum_name = reset($forum_rows)['forum_name'];
 
     reset($simple_auth_ary);

--- a/src/Sitemap.php
+++ b/src/Sitemap.php
@@ -72,7 +72,7 @@ class Sitemap
 
         while ($row = DB()->sql_fetchrow($sql)) {
             $forumUrls[] = [
-                'url' => \url()->forum((int)$row['forum_id'], $row['forum_name']),
+                'url' => url()->forum((int)$row['forum_id'], $row['forum_name']),
                 'time' => $row['last_topic_time'],
             ];
         }
@@ -96,7 +96,7 @@ class Sitemap
 
         while ($row = DB()->sql_fetchrow($sql)) {
             $topicUrls[] = [
-                'url' => \url()->topic((int)$row['topic_id'], $row['topic_title']),
+                'url' => url()->topic((int)$row['topic_id'], $row['topic_title']),
                 'time' => $row['topic_last_post_time'],
             ];
         }


### PR DESCRIPTION
## Summary
- `admin_forumauth.php?f=<bad-id>` crashed with HTTP 500 and the generic "Sorry, something went wrong" page when the requested forum did not exist.
- Root cause: `reset(\$forum_rows)['forum_name']` on an empty rowset (functions ErrorException "Trying to access array offset on false" at `app/Http/Controllers/Admin/admin_forumauth.php:144`).
- Fix: bail out earlier with the existing `FORUM_NOT_EXIST` language string and a real 404 status when no forum matches the provided id.

## Test plan
- [x] Reproduce the crash on `master` by opening `https://tp.test/admin/admin_forumauth.php?f=99999` — server returns 500 and `php_whoops.log` shows the array-offset error.
- [x] Apply the fix and reload the same URL — 404 with friendly "The forum you selected does not exist." message; no entry in `php_whoops.log`.
- [x] Existing flows still work: opening valid `f=1` (Your first forum) or selecting a forum via "Look up Forum" continues to render the simple/advanced permission grid normally.

## Found while auditing
This came out of a manual UI audit of three admin pages:
- `/admin/index.php?pane=right` — all AJAX maintenance actions, "Show users online", "Create profile" verified.
- `/admin/admin_forums.php` — full CRUD on categories and forums (create/edit/delete/move/sub-forum/sync) verified.
- `/admin/admin_forumauth.php` — simple/advanced modes, Submit/Reset/Apply-to-subforums verified.

Other observations not addressed by this PR:
- `bb_die()` defaults to HTTP 500 even for success messages (`functions.php:1142`), so every successful admin update (`FORUMS_UPDATED`, `FORUM_AUTH_UPDATED`, …) returns a 500 status with an OK body. Cross-cutting legacy concern — left for a dedicated PR.
- During the audit the previously merged fixes `c94d572b` (frameset paths) and `4b34efc2` (CLI/FPM cache root) were verified to resolve the earlier 404-on-frames and 419-on-AJAX issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)