### PR TITLE
security(admin): wire CSRF token into all admin POST forms

### DIFF
--- a/resources/views/admin/admin_board.tpl
+++ b/resources/views/admin/admin_board.tpl
@@ -8,7 +8,7 @@
 <a href="admin_board.php?mode=config_mods">{L_CONFIG_MODS}</a>
 <br /><br />
 
-<form action="{S_CONFIG_ACTION}" method="post">
+<form action="{S_CONFIG_ACTION}" method="post">{CSRF_FIELD}
 {S_HIDDEN_FIELDS}
 
 <table class="forumline">
@@ -155,7 +155,7 @@
 <a href="admin_board.php?mode=config_mods" class="bold">{L_CONFIG_MODS}</a>
 <br /><br />
 
-<form action="{S_CONFIG_ACTION}" method="post">
+<form action="{S_CONFIG_ACTION}" method="post">{CSRF_FIELD}
 {S_HIDDEN_FIELDS}
 
 <table class="forumline">

--- a/resources/views/admin/admin_bt_forum_cfg.tpl
+++ b/resources/views/admin/admin_bt_forum_cfg.tpl
@@ -1,6 +1,6 @@
 <h1>{L_FORUM_CONFIG}</h1>
 
-<form action="{S_CONFIG_ACTION}" method="post">
+<form action="{S_CONFIG_ACTION}" method="post">{CSRF_FIELD}
 {S_HIDDEN_FIELDS}
 
 <table class="forumline wAuto">

--- a/resources/views/admin/admin_cron.tpl
+++ b/resources/views/admin/admin_cron.tpl
@@ -20,7 +20,7 @@ tr.hl-tr:hover td { background-color: #CFC !important; }
 
 <!-- IF TPL_CRON_LIST -->
 <!--========================================================================-->
-<form action="{S_CRON_ACTION}" method="post">
+<form action="{S_CRON_ACTION}" method="post">{CSRF_FIELD}
 <input class="text" type="hidden" name="mode" value="{S_MODE}" />
 
 <table cellpadding="2" cellspacing="0" width="100%">
@@ -129,7 +129,7 @@ tr.hl-tr:hover td { background-color: #CFC !important; }
 <a href="admin_cron.php?mode=list">{L_CRON_LIST}</a>
 <br /><br />
 
-<form action="{S_CRON_ACTION}" method="post">
+<form action="{S_CRON_ACTION}" method="post">{CSRF_FIELD}
 <input class="text" type="hidden" name="mode" value="{S_MODE}" />
 
 <table class="forumline">

--- a/resources/views/admin/admin_disallow.tpl
+++ b/resources/views/admin/admin_disallow.tpl
@@ -3,7 +3,7 @@
 <p>{L_DISALLOW_EXPLAIN}</p>
 <br/>
 
-<form method="post" action="{S_FORM_ACTION}">
+<form method="post" action="{S_FORM_ACTION}">{CSRF_FIELD}
     <table class="forumline wAuto">
         <col class="row1">
         <col class="row2">

--- a/resources/views/admin/admin_forum_prune.tpl
+++ b/resources/views/admin/admin_forum_prune.tpl
@@ -8,7 +8,7 @@
 
 <br />
 
-<form action="{S_PRUNE_ACTION}" method="post">
+<form action="{S_PRUNE_ACTION}" method="post">{CSRF_FIELD}
 
 <table class="forumline wAuto">
 <!-- IF PRUNED_TOTAL -->

--- a/resources/views/admin/admin_forumauth.tpl
+++ b/resources/views/admin/admin_forumauth.tpl
@@ -8,7 +8,7 @@
 
 <br />
 
-<form method="post" action="{S_AUTH_ACTION}">
+<form method="post" action="{S_AUTH_ACTION}">{CSRF_FIELD}
 {S_HIDDEN_FIELDS}
 
 <table class="forumline wAuto">
@@ -34,7 +34,7 @@
 
 <h2>{L_FORUM}: <a href="{U_VIEWFORUM}">{FORUM_NAME}</a></h2>
 
-<form method="post" action="{S_FORUMAUTH_ACTION}">
+<form method="post" action="{S_FORUMAUTH_ACTION}">{CSRF_FIELD}
 {S_HIDDEN_FIELDS}
 
 <table class="forumline wAuto">

--- a/resources/views/admin/admin_forumauth_list.tpl
+++ b/resources/views/admin/admin_forumauth_list.tpl
@@ -64,7 +64,7 @@
 </table>
 <br />
 
-<form method="post" action="{S_FORUMAUTH_ACTION}">
+<form method="post" action="{S_FORUMAUTH_ACTION}">{CSRF_FIELD}
 <table class="forumline med">
 	<tr>
 		<th>&nbsp;</th>

--- a/resources/views/admin/admin_forums.tpl
+++ b/resources/views/admin/admin_forums.tpl
@@ -21,7 +21,7 @@ function toggle_cat_list (val)
 <p>{L_FORUM_EDIT_DELETE_EXPLAIN}</p>
 <br />
 
-<form method="post" action="{S_FORUM_ACTION}" name="frm">
+<form method="post" action="{S_FORUM_ACTION}" name="frm">{CSRF_FIELD}
 {S_HIDDEN_FIELDS}
 
 <table class="forumline pad_4">
@@ -99,7 +99,7 @@ function toggle_cat_list (val)
 <p>{L_EDIT_CATEGORY_EXPLAIN}</p>
 <br />
 
-<form method="post" action="{S_FORUM_ACTION}">
+<form method="post" action="{S_FORUM_ACTION}">{CSRF_FIELD}
 {S_HIDDEN_FIELDS}
 
 <table class="forumline">
@@ -129,7 +129,7 @@ function toggle_cat_list (val)
 <p>{L_FORUM_DELETE_EXPLAIN}</p>
 <br />
 
-<form method="post" action="{S_FORUM_ACTION}">
+<form method="post" action="{S_FORUM_ACTION}">{CSRF_FIELD}
 {S_HIDDEN_FIELDS}
 
 <table class="forumline">
@@ -185,7 +185,7 @@ function hl (id, on)
 <p>{L_FORUM_EDIT_DELETE_EXPLAIN}</p>
 <br />
 
-<form method="post" action="{S_FORUM_ACTION}">
+<form method="post" action="{S_FORUM_ACTION}">{CSRF_FIELD}
 
 <!-- BEGIN c -->
 <table class="forumline">

--- a/resources/views/admin/admin_groups.tpl
+++ b/resources/views/admin/admin_groups.tpl
@@ -3,7 +3,7 @@
 
 <h1>{L_GROUP_ADMINISTRATION}</h1>
 
-<form action="{S_GROUP_ACTION}" method="post" name="post">
+<form action="{S_GROUP_ACTION}" method="post" name="post">{CSRF_FIELD}
 {S_HIDDEN_FIELDS}
 
 <table class="forumline wAuto">
@@ -74,7 +74,7 @@
 
 <br /><br />
 
-<form method="post" action="{S_GROUP_ACTION}">
+<form method="post" action="{S_GROUP_ACTION}">{CSRF_FIELD}
 {S_HIDDEN_FIELDS}
 
 <table class="forumline wAuto">

--- a/resources/views/admin/admin_log.tpl
+++ b/resources/views/admin/admin_log.tpl
@@ -18,7 +18,7 @@
 
 <h1>{L_ACTIONS_LOG}</h1>
 
-<form action="{S_LOG_ACTION}" method="post">
+<form action="{S_LOG_ACTION}" method="post">{CSRF_FIELD}
     <!-- IF TOPIC_CSV --><input type="hidden" name="{#POST_TOPIC_URL#}" value="{TOPIC_CSV}"/><!-- ENDIF -->
 
     <table class="bordered w100" cellspacing="0">

--- a/resources/views/admin/admin_mass_email.tpl
+++ b/resources/views/admin/admin_mass_email.tpl
@@ -3,7 +3,7 @@
 <p>{L_MASS_EMAIL_EXPLAIN}</p>
 <br/>
 
-<form method="post" action="{S_USER_ACTION}" onSubmit="return checkForm(this);">
+<form method="post" action="{S_USER_ACTION}" onSubmit="return checkForm(this);">{CSRF_FIELD}
     <table class="forumline">
         <tr>
             <th colspan="2">{L_COMPOSE}</th>

--- a/resources/views/admin/admin_ranks.tpl
+++ b/resources/views/admin/admin_ranks.tpl
@@ -6,7 +6,7 @@
 <p>{L_RANKS_EXPLAIN}</p>
 <br />
 
-<form action="{S_RANK_ACTION}" method="post">
+<form action="{S_RANK_ACTION}" method="post">{CSRF_FIELD}
 {S_HIDDEN_FIELDS}
 
 <table class="forumline wAuto">
@@ -80,7 +80,7 @@
 <p>{L_RANKS_EXPLAIN}</p>
 <br />
 
-<form method="post" action="{S_RANKS_ACTION}">
+<form method="post" action="{S_RANKS_ACTION}">{CSRF_FIELD}
 
 <table class="forumline w80">
 <tr>

--- a/resources/views/admin/admin_rebuild_search.tpl
+++ b/resources/views/admin/admin_rebuild_search.tpl
@@ -45,7 +45,7 @@ function swap_values()
 
 <br />
 
-<form name="rebuild" method="post" action="{S_REBUILD_SEARCH_ACTION}" onsubmit="update_button(rebuild.submit);">
+<form name="rebuild" method="post" action="{S_REBUILD_SEARCH_ACTION}" onsubmit="update_button(rebuild.submit);">{CSRF_FIELD}
 {S_HIDDEN_FIELDS}
 
 <table class="forumline wAuto med">
@@ -145,7 +145,7 @@ function updateButton()
 
 <div class="spacer_2"></div>
 
-<form name="form_rebuild_progress" method="post" action="{S_REBUILD_SEARCH_ACTION}">
+<form name="form_rebuild_progress" method="post" action="{S_REBUILD_SEARCH_ACTION}">{CSRF_FIELD}
 
 <table class="forumline w80 med">
 	<tr>

--- a/resources/views/admin/admin_robots.tpl
+++ b/resources/views/admin/admin_robots.tpl
@@ -1,7 +1,7 @@
 <h1>{L_ROBOTS_TXT_EDITOR_TITLE}</h1>
 <br />
 
-<form action="{S_ACTION}" method="post">
+<form action="{S_ACTION}" method="post">{CSRF_FIELD}
     <table class="forumline">
         <tr>
             <th>{L_ROBOTS_TXT_EDITOR_TITLE}</th>

--- a/resources/views/admin/admin_sitemap.tpl
+++ b/resources/views/admin/admin_sitemap.tpl
@@ -58,7 +58,7 @@
 
 <h1>{L_SITEMAP_ADMIN}</h1>
 
-<form action="admin_sitemap.php" method="post">
+<form action="admin_sitemap.php" method="post">{CSRF_FIELD}
     <table class="forumline">
         <tr class="row1">
             <td width="25%"><span class="gen"><b>{L_INFORMATION}:</b></span></td>

--- a/resources/views/admin/admin_smilies.tpl
+++ b/resources/views/admin/admin_smilies.tpl
@@ -6,7 +6,7 @@
 <p>{L_SMILE_DESC}</p>
 <br />
 
-<form method="post" action="{S_SMILEY_ACTION}">
+<form method="post" action="{S_SMILEY_ACTION}">{CSRF_FIELD}
 {S_HIDDEN_FIELDS}
 
 <table class="forumline">
@@ -50,7 +50,7 @@ function update_smiley(newimage)
 }
 </script>
 
-<form method="post" action="{S_SMILEY_ACTION}">
+<form method="post" action="{S_SMILEY_ACTION}">{CSRF_FIELD}
 {S_HIDDEN_FIELDS}
 
 <table class="forumline">
@@ -87,7 +87,7 @@ function update_smiley(newimage)
 <p>{L_SMILEY_IMPORT_INST}</p>
 <br />
 
-<form method="post" action="{S_SMILEY_ACTION}">
+<form method="post" action="{S_SMILEY_ACTION}">{CSRF_FIELD}
 {S_HIDDEN_FIELDS}
 
 <table class="forumline">

--- a/resources/views/admin/admin_terms.tpl
+++ b/resources/views/admin/admin_terms.tpl
@@ -3,7 +3,7 @@
 <p>{L_TERMS_EXPLAIN}</p>
 <br />
 
-<form action="{S_ACTION}" method="post">
+<form action="{S_ACTION}" method="post">{CSRF_FIELD}
 	<table class="forumline">
 		<tr>
 			<th>{L_TERMS}</th>

--- a/resources/views/admin/admin_ug_auth.tpl
+++ b/resources/views/admin/admin_ug_auth.tpl
@@ -90,7 +90,7 @@ thead tr {
 <p>{T_AUTH_EXPLAIN}</p>
 <br />
 
-<form method="post" action="{S_AUTH_ACTION}">
+<form method="post" action="{S_AUTH_ACTION}">{CSRF_FIELD}
 {S_HIDDEN_FIELDS}
 
 <div class="tScrollContainer" id="tScrollCont">
@@ -173,7 +173,7 @@ thead tr {
 <input type="hidden" name="{#POST_CAT_URL#}" value="{SELECTED_CAT}" />
 </form>
 
-<form method="post" action="{S_AUTH_ACTION}">
+<form method="post" action="{S_AUTH_ACTION}">{CSRF_FIELD}
 {S_HIDDEN_FIELDS}
 
 <p class="gen">{T_USER_OR_GROUPNAME}: <b>{USER_OR_GROUPNAME}</b></p>
@@ -260,7 +260,7 @@ function mark_changed (f_id, acl_id)
 <p>{L_USER_AUTH_EXPLAIN}</p>
 <br /><br />
 
-<form method="post" name="post" action="{S_AUTH_ACTION}">
+<form method="post" name="post" action="{S_AUTH_ACTION}">{CSRF_FIELD}
 <input type="hidden" name="mode" value="edit" />
 {S_HIDDEN_FIELDS}
 
@@ -296,7 +296,7 @@ function mark_changed (f_id, acl_id)
 <p>{L_GROUP_AUTH_EXPLAIN}</p>
 <br /><br />
 
-<form method="post" action="{S_AUTH_ACTION}">
+<form method="post" action="{S_AUTH_ACTION}">{CSRF_FIELD}
 {S_HIDDEN_FIELDS}
 
 <table class="forumline wAuto">

--- a/resources/views/admin/admin_user_ban.tpl
+++ b/resources/views/admin/admin_user_ban.tpl
@@ -3,7 +3,7 @@
 <p>{L_BAN_EXPLAIN}</p>
 <br />
 
-<form method="post" name="post" action="{S_BANLIST_ACTION}">
+<form method="post" name="post" action="{S_BANLIST_ACTION}">{CSRF_FIELD}
 
 <table width="80%" class="forumline">
 	<tr>

--- a/resources/views/admin/admin_user_search.tpl
+++ b/resources/views/admin/admin_user_search.tpl
@@ -6,7 +6,7 @@
 <p>{L_SEARCH_USERS_EXPLAIN}</p>
 <br />
 
-<form method="post" name="post" action="{S_SEARCH_ACTION}"><input type="hidden" name="dosearch" value="true" />
+<form method="post" name="post" action="{S_SEARCH_ACTION}">{CSRF_FIELD}<input type="hidden" name="dosearch" value="true" />
 
 <table class="forumline">
 	<tr>
@@ -110,7 +110,7 @@
 <p>{NEW_SEARCH}</p>
 <br />
 
-<form action="{S_POST_ACTION}" method="post" name="post">
+<form action="{S_POST_ACTION}" method="post" name="post">{CSRF_FIELD}
 <table width="98%" class="bCenter">
 	<tr>
 		<td class="nav tCenter"><span class="gen">{L_SORT_OPTIONS}</span> <a href="{U_USERNAME}">{L_USERNAME}</a> | <a href="{U_EMAIL}">{L_EMAIL_ADDRESS}</a> | <a href="{U_POSTS}">{L_POSTS}</a> | <a href="{U_JOINDATE}">{L_JOINED}</a> | <a href="{U_LASTVISIT}">{L_LAST_VISIT}</a></td>

--- a/resources/views/admin/admin_words.tpl
+++ b/resources/views/admin/admin_words.tpl
@@ -6,7 +6,7 @@
 <p>{L_WORDS_EXPLAIN}</p>
 <br/>
 
-<form method="post" action="{S_WORDS_ACTION}">
+<form method="post" action="{S_WORDS_ACTION}">{CSRF_FIELD}
     <table class="forumline">
         <tr>
             <th>{L_WORD}</th>
@@ -41,7 +41,7 @@
 <p>{L_WORDS_EXPLAIN}</p>
 <br/>
 
-<form method="post" action="{S_WORDS_ACTION}">
+<form method="post" action="{S_WORDS_ACTION}">{CSRF_FIELD}
     <table class="forumline">
         <tr>
             <th colspan="2">{L_EDIT_WORD_CENSOR}</th>

--- a/src/Sitemap.php
+++ b/src/Sitemap.php
@@ -72,7 +72,7 @@ class Sitemap
 
         while ($row = DB()->sql_fetchrow($sql)) {
             $forumUrls[] = [
-                'url' => \url()->forum((int)$row['forum_id'], $row['forum_name']),
+                'url' => url()->forum((int)$row['forum_id'], $row['forum_name']),
                 'time' => $row['last_topic_time'],
             ];
         }
@@ -96,7 +96,7 @@ class Sitemap
 
         while ($row = DB()->sql_fetchrow($sql)) {
             $topicUrls[] = [
-                'url' => \url()->topic((int)$row['topic_id'], $row['topic_title']),
+                'url' => url()->topic((int)$row['topic_id'], $row['topic_title']),
                 'time' => $row['topic_last_post_time'],
             ];
         }

--- a/src/Template/Template.php
+++ b/src/Template/Template.php
@@ -14,6 +14,7 @@ use Exception;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Str;
 use RuntimeException;
+use TorrentPier\Http\Csrf;
 use Twig\Environment;
 
 /**
@@ -466,6 +467,14 @@ class Template
         }
         $this->variables['TEMPLATE'] ??= $tpl;
         $this->variables['TEMPLATE_NAME'] ??= $this->templateName;
+
+        // CSRF helpers for legacy .tpl forms.
+        // Token() returns '' for guests outside an active session — emit the
+        // input anyway, the middleware will reject the eventual POST.
+        $token = Csrf::token();
+        $this->variables['CSRF_TOKEN'] ??= $token;
+        $this->variables['CSRF_FIELD'] ??= '<input type="hidden" name="'
+            . Csrf::FIELD . '" value="' . htmlspecialchars($token, ENT_QUOTES) . '">';
 
         $this->twig->addGlobal('V', $this->variables);
     }


### PR DESCRIPTION
## Summary

Follow-up to a59c02f6 (which deliberately left admin without a CSRF token). Right after that commit, `$router->middleware('csrf')` in `routes/web.php` started rejecting every admin POST with 419 — admins can no longer save anything.

This PR closes the gap from the admin side:

- `Template::initStartupVars()` now exposes `CSRF_FIELD` (hidden input) and `CSRF_TOKEN` (raw value) as default template vars. Twig autoescape is already off for legacy `.tpl`, so the HTML renders raw.
- Each `<form ... method="post">` under `resources/views/admin/*.tpl` now emits `{CSRF_FIELD}` immediately after the opening tag (37 forms across 21 files). Existing POST handlers work unchanged.

## Manual verification

Tested via Playwright + DB checks on `tp.test`:

- [x] `admin_cron.php`: add/edit/mass disable/enable POST works, persists, no more 419 (was 100% broken before).
- [x] `admin_bt_forum_cfg.php`: submit with `confirm=1` updates `bb_config` and `bb_forums` rows.
- [x] `admin_log.php`: search form submits cleanly with CSRF validation.
- [x] Tracker/api POST without `_token` still returns 419 (regression test passes).
- [x] `session_id` rotates per request in TorrentPier, but `Csrf::cacheKey()` keys on the cookie `sid` which `StartSession` reuses when the session is still valid, so the token stays stable across consecutive GETs in the same session.

## Out of scope (separately filed)

Found while testing the three admin pages above:

- `admin_cron.php?mode=delete&id=X` and `mode=run` are state-changing GET endpoints (no CSRF). Worth converting to POST.
- `admin_cron.php?mode=run` with an invalid `cron_script` 500s ("Sorry, …") instead of a friendly error.
- `admin_cron.php?mode=edit&id=99999` 500s on missing row.
- `admin_cron.php?mode=delete&id=99999` reports "removed successfully" even when nothing existed.
- `admin_cron.php` without `?mode=…` renders an empty body — could redirect to `?mode=list`.
- `admin_bt_forum_cfg.php` submit returns HTTP 500 even though the body says "Configuration Updated Successfully" and rows persist — probably a header-after-output edge case.
- `admin_log.php?tm=…` filters in SQL but does not reflect the value back into the form (`$title_match_val` stays empty).
- `Cron.php:24` `\define('IN_CRON', true)` without `defined()` guard — double Run within the same request triggers a PHP 9 deprecation that Whoops turns into a 500.

These are tracked separately and can land as a follow-up.

## Test plan

- [x] `admin_cron.php` add/edit/disable/enable/delete all work via UI
- [x] `admin_bt_forum_cfg.php` submit applies values to `bb_config` / `bb_forums`
- [x] `admin_log.php` filters (`type`, `u`, `f`, `dt`, `db`, `sort`, `tm`, `start`) keep working
- [x] Non-admin web POST without `_token` still rejected with 419

🤖 Generated with [Claude Code](https://claude.com/claude-code)