### PR TITLE
fix(admin): repair user search pagination, sort toggle, dropdowns

### DIFF
--- a/app/Http/Controllers/Admin/admin_user_search.php
+++ b/app/Http/Controllers/Admin/admin_user_search.php
@@ -809,7 +809,7 @@ if (!request()->get('dosearch')) {
         $select_sql .= 'u.username';
     }
 
-    $reqOrder = strtoupper((string) request()->get('order'));
+    $reqOrder = strtoupper((string)request()->get('order'));
     if ($reqOrder === 'DESC') {
         $order = 'DESC';
         $o_order = 'ASC';
@@ -885,7 +885,7 @@ if (!request()->get('dosearch')) {
     $banned = [];
 
     if ($rowset) {
-        $user_ids = array_map(static fn ($row) => (int) $row['user_id'], $rowset);
+        $user_ids = array_map(static fn ($row) => (int)$row['user_id'], $rowset);
         $sql = 'SELECT ban_userid AS user_id FROM ' . BB_BANLIST . ' WHERE ban_userid IN (' . implode(', ', $user_ids) . ')';
 
         if (!$result = DB()->sql_query($sql)) {

--- a/app/Http/Controllers/Admin/admin_user_search.php
+++ b/app/Http/Controllers/Admin/admin_user_search.php
@@ -78,7 +78,7 @@ if (!request()->get('dosearch')) {
         }
     }
 
-    $lastvisited = [1, 7, 14, 30, 60, 120, 365, 500, 730, 1000];
+    $lastvisited = [1, 7, 14, 30, 90, 180, 365, 730];
     $lastvisited_list = '';
 
     foreach ($lastvisited as $days) {
@@ -809,12 +809,13 @@ if (!request()->get('dosearch')) {
         $select_sql .= 'u.username';
     }
 
-    if (request()->get('order')) {
-        $o_order = 'ASC';
+    $reqOrder = strtoupper((string) request()->get('order'));
+    if ($reqOrder === 'DESC') {
         $order = 'DESC';
+        $o_order = 'ASC';
     } else {
-        $o_order = 'DESC';
         $order = 'ASC';
+        $o_order = 'DESC';
     }
 
     $select_sql .= " {$order}";
@@ -881,24 +882,19 @@ if (!request()->get('dosearch')) {
 
     $rowset = DB()->sql_fetchrowset($result);
 
-    $users_sql = '';
-
-    foreach ($rowset as $array) {
-        $users_sql .= ($users_sql == '') ? $array['user_id'] : ', ' . $array['user_id'];
-    }
-
-    $sql = 'SELECT ban_userid AS user_id FROM ' . BB_BANLIST . " WHERE ban_userid IN ({$users_sql})";
-
-    if (!$result = DB()->sql_query($sql)) {
-        bb_die('Could not select banned data');
-    }
-
-    unset($banned);
-
     $banned = [];
 
-    while ($row = DB()->sql_fetchrow($result)) {
-        $banned[$row['user_id']] = true;
+    if ($rowset) {
+        $user_ids = array_map(static fn ($row) => (int) $row['user_id'], $rowset);
+        $sql = 'SELECT ban_userid AS user_id FROM ' . BB_BANLIST . ' WHERE ban_userid IN (' . implode(', ', $user_ids) . ')';
+
+        if (!$result = DB()->sql_query($sql)) {
+            bb_die('Could not select banned data');
+        }
+
+        while ($row = DB()->sql_fetchrow($result)) {
+            $banned[$row['user_id']] = true;
+        }
     }
 
     for ($i = 0, $iMax = count($rowset); $i < $iMax; $i++) {

--- a/resources/views/admin/admin_user_search.tpl
+++ b/resources/views/admin/admin_user_search.tpl
@@ -59,7 +59,7 @@
 		<td class="row2">&nbsp;</td>
 	</tr>
 	<tr>
-		<td class="row1"><span class="gen"><b>{L_USERFIELD}:</b>&nbsp;<select name="userfield_type"><option value="twitter">{L_TWITTER}</option><option value="website">{L_WEBSITE}</option><option value="location">{L_LOCATION}</option><option value="interests">{L_INTERESTS}</option></select>&nbsp;<input class="post" type="text" name="userfield_value" maxlength="25" size="25" />&nbsp;<input type="submit" class="post2" name="search_userfield" value="{L_SEARCH}" /></span><br /><span class="small">{L_SEARCH_USERS_USERFIELD_EXPLAIN}</span></td>
+		<td class="row1"><span class="gen"><b>{L_USERFIELD}:</b>&nbsp;<select name="userfield_type"><option value="twitter">{L_TWITTER}</option><option value="website">{L_WEBSITE}</option><option value="location">{L_LOCATION}</option><option value="interests">{L_INTERESTS}</option><option value="occupation">{L_OCCUPATION}</option></select>&nbsp;<input class="post" type="text" name="userfield_value" maxlength="25" size="25" />&nbsp;<input type="submit" class="post2" name="search_userfield" value="{L_SEARCH}" /></span><br /><span class="small">{L_SEARCH_USERS_USERFIELD_EXPLAIN}</span></td>
 	</tr>
 	<tr>
 		<td class="row2">&nbsp;</td>

--- a/src/Sitemap.php
+++ b/src/Sitemap.php
@@ -72,7 +72,7 @@ class Sitemap
 
         while ($row = DB()->sql_fetchrow($sql)) {
             $forumUrls[] = [
-                'url' => \url()->forum((int)$row['forum_id'], $row['forum_name']),
+                'url' => url()->forum((int)$row['forum_id'], $row['forum_name']),
                 'time' => $row['last_topic_time'],
             ];
         }
@@ -96,7 +96,7 @@ class Sitemap
 
         while ($row = DB()->sql_fetchrow($sql)) {
             $topicUrls[] = [
-                'url' => \url()->topic((int)$row['topic_id'], $row['topic_title']),
+                'url' => url()->topic((int)$row['topic_id'], $row['topic_title']),
                 'time' => $row['topic_last_post_time'],
             ];
         }


### PR DESCRIPTION
## Summary

Manual QA of `/admin/admin_user_search.php` surfaced four issues. All four are fixed in this PR; the spam-log page was tested in the same pass and behaves correctly.

### 1. SQL crash on out-of-range page
**Repro:** `?dosearch=true&search_misc=true&misc=admins&page=99` → page 99 of 1 yields zero rows → `users_sql` stays empty → query becomes `WHERE ban_userid IN ()` → `bb_die('Could not select banned data')`.
**Fix:** skip the banlist lookup entirely when `$rowset` is empty (the user table iteration below it already handles the empty case). The IN clause is also rebuilt with `implode`/`(int)` casting instead of manual string concatenation while we were in there.

### 2. Sort toggle stuck on DESC
**Repro:** click any sort header twice on a result page (e.g. Posts). First click sends `&order=DESC` (data flips). Subsequent clicks alternate the URL `…&order=ASC` ↔ `…&order=DESC` but the actual ORDER BY stays DESC.
**Cause:** the old branch ignored the value of `order` and hard-coded `$order = 'DESC'` whenever the parameter was present.
**Fix:** read the actual value and pick `$order` / `$o_order` from it.

### 3. Missing Occupation in "User field" dropdown
The controller accepts `userfield_type=occupation` and the `L_OCCUPATION` translation exists, but the template only exposed twitter/website/location/interests. Added the option.

### 4. Duplicate labels in "Users who have visited"
Carbon's `diffForHumans` rounds the previous values into the same string:
- 30 and 60 days → "1 month before"
- 365 and 500 days → "1 year before"
- 730 and 1000 days → "2 years before"
Replaced with `[1, 7, 14, 30, 90, 180, 365, 730]` which renders eight distinct options.

## Test plan
- [x] `/admin/admin_user_search.php?…&page=99` no longer produces "Could not select banned data"; renders empty results with a `Back` link
- [x] `/admin/admin_user_search.php?…&sort=posts&order=DESC` shows DESC order with a toggle link to `&order=ASC` and vice-versa; data matches the URL
- [x] Main form's User field dropdown lists Occupation; `search_userfield=occupation` still works end-to-end
- [x] "Users who have visited" dropdown shows eight distinct entries
- [x] All thirteen search modes (username, email, ip, joindate, group, rank, postcount, userfield, lastvisited, language, timezone, moderators, misc) still return correct results