### PR TITLE
security(admin): escape admin_log MSG/TOPIC_TITLE and admin_user_search rank dropdown

### DIFF
--- a/app/Http/Controllers/Admin/admin_log.php
+++ b/app/Http/Controllers/Admin/admin_log.php
@@ -288,12 +288,12 @@ if ($log_rowset) {
             'TOPIC_ID' => $row['log_topic_id'],
             'TOPIC_HREF' => (!$topic_deleted) ? BB_ROOT . TOPIC_URL . $row['log_topic_id'] : '',
             'TOPIC_HREF_S' => url_arg($url, $topic_key, $row['log_topic_id']),
-            'TOPIC_TITLE' => $topic_title,
+            'TOPIC_TITLE' => htmlCHR($topic_title),
 
             'TOPIC_ID_NEW' => $row['log_topic_id_new'],
             'TOPIC_HREF_NEW' => BB_ROOT . TOPIC_URL . $row['log_topic_id_new'],
             'TOPIC_HREF_NEW_S' => url_arg($url, $topic_key, $row['log_topic_id_new']),
-            'TOPIC_TITLE_NEW' => $topic_title_new,
+            'TOPIC_TITLE_NEW' => htmlCHR($topic_title_new),
 
             'DATETIME' => bb_date($row['log_time'], 'd-M-y H:i'),
             'DATETIME_HREF_S' => $datetime_href_s,
@@ -304,7 +304,7 @@ if ($log_rowset) {
         // Topics
         if ($topic_csv && empty($filter['topics'][$row['log_topic_title']])) {
             template()->assign_block_vars('topics', [
-                'TOPIC_TITLE' => $row['log_topic_title'],
+                'TOPIC_TITLE' => htmlCHR($row['log_topic_title']),
             ]);
             $filter['topics'][$row['log_topic_title']] = true;
         }

--- a/app/Http/Controllers/Admin/admin_user_search.php
+++ b/app/Http/Controllers/Admin/admin_user_search.php
@@ -46,7 +46,7 @@ if (!request()->get('dosearch')) {
         while ($row = DB()->sql_fetchrow($result)) {
             $rank = $row['rank_title'];
             $rank_id = $row['rank_id'];
-            $rank_select_box .= '<option value="' . $rank_id . '">' . $rank . '</option>';
+            $rank_select_box .= '<option value="' . $rank_id . '">' . htmlCHR($rank) . '</option>';
         }
     }
 

--- a/app/Http/Controllers/Api/Ajax/ChangeTorStatusController.php
+++ b/app/Http/Controllers/Api/Ajax/ChangeTorStatusController.php
@@ -133,7 +133,7 @@ class ChangeTorStatusController
         // Log action
         $logMsg = \sprintf(__('TOR_STATUS_LOG_ACTION'), config()->get('tracker.tor_icons')[$newStatus] . ' <b> ' . __('TOR_STATUS_NAME')[$newStatus] . '</b>', config()->get('tracker.tor_icons')[$tor['tor_status']] . ' <b> ' . __('TOR_STATUS_NAME')[$tor['tor_status']] . '</b>');
         if ($comment && $comment != __('COMMENT')) {
-            $logMsg .= '<br/>' . __('COMMENT') . ": <b>$comment</b>.";
+            $logMsg .= '<br/>' . __('COMMENT') . ': <b>' . htmlCHR($comment) . '</b>.';
         }
         log_action()->mod('mod_topic_change_tor_status', [
             'forum_id' => $tor['forum_id'],

--- a/src/Legacy/Admin/Common.php
+++ b/src/Legacy/Admin/Common.php
@@ -814,7 +814,7 @@ class Common
             $sql = 'SELECT user_id, username FROM ' . BB_USERS . " WHERE user_id IN({$user_csv})";
 
             foreach (DB()->fetch_rowset($sql) as $row) {
-                $users_log_msg[] = "<b>{$row['username']}</b> [{$row['user_id']}]";
+                $users_log_msg[] = '<b>' . htmlCHR($row['username']) . '</b> [' . (int)$row['user_id'] . ']';
             }
         }
 


### PR DESCRIPTION
## Summary

Two stored XSS paths surfaced while auditing v3.0.3 follow-up commits:

- **admin_user_search.php:49** — `rank_title` rendered raw inside `<option>` (sibling dropdown lines at 73/77 already use `htmlCHR`). A `<script>` saved as a rank title fires for any admin opening the user search page; browsers do execute `<script>` inside `<option>`.
- **admin_log.php:291/296/307** — `TOPIC_TITLE`, `TOPIC_TITLE_NEW` and the per-topic filter chip render `log_topic_title*` raw. Topic titles aren't HTML-sanitized on insert (`src/Legacy/Post.php:51` only reverses `&amp;`→`&`), so a user creating a topic titled `<script>...</script>` and any subsequent logged mod action lands raw script tags into the admin log viewer.

The MSG cell in `admin_log.tpl` is intentionally HTML (callers wrap with `<b>`/`<br/>`), so escape the user-controlled sub-strings at the source rather than at output:

- `src/Legacy/Admin/Common.php:817` — `htmlCHR($row['username'])`, plus `(int)` cast on user_id.
- `ChangeTorStatusController.php:136` — escape the moderator comment before splicing into `<b>...</b>`.

`ModActionController` and `ChangeTorrentController` log_msg paths only compose translated strings + admin-typed config, no user input flows in.

## Test plan

- [x] admin_user_search rank dropdown: payload `<script>window._xss_test=true</script>` saved as rank title — Playwright load of `/admin/admin_user_search.php` no longer fires (was firing before)
- [x] admin_log TOPIC_TITLE/TOPIC_TITLE_NEW: malicious log rows with `<script>` topic titles — `/admin/admin_log.php` no longer fires `_log_xss*`
- [x] Existing FORUM_NAME / cat/forum dropdown escaping unchanged (already-correct sibling pattern)
- [x] log_msg HTML formatting (`<b>`, `<br/>`) preserved end-to-end via source-side escaping
- [ ] @codex review
- [ ] @claude review

🤖 Generated with [Claude Code](https://claude.com/claude-code)