### PR TITLE
fix(csrf): keep token alive across guest and login 3-min idle

### DIFF
--- a/app/Http/Controllers/Api/CsrfTokenController.php
+++ b/app/Http/Controllers/Api/CsrfTokenController.php
@@ -22,7 +22,6 @@ final class CsrfTokenController
     public function __invoke(ServerRequestInterface $request): ResponseInterface
     {
         return (new JsonResponse(['token' => Csrf::token()]))
-            ->withHeader('Cache-Control', 'no-store')
-            ->withHeader('Pragma', 'no-cache');
+            ->withHeader('Cache-Control', 'no-store');
     }
 }

--- a/app/Http/Controllers/Api/CsrfTokenController.php
+++ b/app/Http/Controllers/Api/CsrfTokenController.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * TorrentPier – Bull-powered BitTorrent tracker engine
+ *
+ * @copyright Copyright (c) 2005-2026 TorrentPier (https://torrentpier.com)
+ * @link      https://github.com/torrentpier/torrentpier for the canonical source repository
+ * @license   https://github.com/torrentpier/torrentpier/blob/master/LICENSE MIT License
+ */
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use Laminas\Diactoros\Response\JsonResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use TorrentPier\Http\Csrf;
+
+final class CsrfTokenController
+{
+    public function __invoke(ServerRequestInterface $request): ResponseInterface
+    {
+        return (new JsonResponse(['token' => Csrf::token()]))
+            ->withHeader('Cache-Control', 'no-store')
+            ->withHeader('Pragma', 'no-cache');
+    }
+}

--- a/public/assets/js/main.js
+++ b/public/assets/js/main.js
@@ -278,7 +278,7 @@ $(document).ready(function () {
       if (retrySettings.data && typeof retrySettings.data === 'object') {
         retrySettings.data = $.extend({}, retrySettings.data, { _token: resp.token });
       } else if (typeof retrySettings.data === 'string') {
-        retrySettings.data = retrySettings.data.replace(/(^|&)_token=[^&]*/, '$1_token=' + encodeURIComponent(resp.token));
+        retrySettings.data = retrySettings.data.replace(/(^|&)_token=[^&]*/g, '$1_token=' + encodeURIComponent(resp.token));
       }
       return $.ajax(retrySettings);
     });

--- a/public/assets/js/main.js
+++ b/public/assets/js/main.js
@@ -262,6 +262,28 @@ $(document).ready(function () {
     });
   }
 
+  var _csrfRefreshPromise = null;
+  window._csrfRefreshAndRetry = function (settings) {
+    if (!settings || settings._csrfRetried) return null;
+    if (!_csrfRefreshPromise) {
+      _csrfRefreshPromise = $.ajax({ url: '/api/csrf', method: 'GET', dataType: 'json', global: false })
+        .always(function () { _csrfRefreshPromise = null; });
+    }
+    return _csrfRefreshPromise.then(function (resp) {
+      if (!resp || !resp.token) return $.Deferred().reject().promise();
+      _csrfToken = resp.token;
+      $('meta[name="csrf-token"]').attr('content', resp.token);
+      $('input[name="_token"]').val(resp.token);
+      var retrySettings = $.extend({}, settings, { _csrfRetried: true });
+      if (retrySettings.data && typeof retrySettings.data === 'object') {
+        retrySettings.data = $.extend({}, retrySettings.data, { _token: resp.token });
+      } else if (typeof retrySettings.data === 'string') {
+        retrySettings.data = retrySettings.data.replace(/(^|&)_token=[^&]*/, '$1_token=' + encodeURIComponent(resp.token));
+      }
+      return $.ajax(retrySettings);
+    });
+  };
+
   // Menus
   $('body').append($('div.menu-sub'));
   $('a.menu-root')
@@ -496,12 +518,26 @@ $(document).ready(function () {
   // Setup ajax-error box
   $("#ajax-error").ajaxError(function (event, xml, settings) {
     var status = xml.status;
+    var $box = $(this);
+    if (status === 419) {
+      var retry = window._csrfRefreshAndRetry && window._csrfRefreshAndRetry(settings);
+      if (retry) {
+        retry.fail(function () {
+          $box.html('<b>Session expired.</b> Please reload the page to continue.').show();
+          ajax.setStatusBoxPosition($box);
+        });
+        return;
+      }
+      $box.html('<b>Session expired.</b> Please reload the page to continue.').show();
+      ajax.setStatusBoxPosition($box);
+      return;
+    }
     var text = xml.statusText;
     if (status === 200) {
       status = '';
       text = 'invalid data format';
     } else if (!text || text === 'error') {
-      text = 'Internal Server Error';
+      text = 'Server Error';
     }
     var url = (settings && settings.url) || xml.responseURL || '';
     var body = xml.responseJSON;
@@ -512,8 +548,8 @@ $(document).ready(function () {
     var detail = (body && body.error_msg)
       ? '<br />' + $('<span>').text(body.error_msg).prop('outerHTML')
       : '';
-    $(this).html(urlPart + "<b>" + status + " " + text + "</b>" + detail).show();
-    ajax.setStatusBoxPosition($(this));
+    $box.html(urlPart + "<b>" + status + " " + text + "</b>" + detail).show();
+    ajax.setStatusBoxPosition($box);
   });
 
   // Bind ajax events

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,6 +8,7 @@
  * @license   https://github.com/torrentpier/torrentpier/blob/master/LICENSE MIT License
  */
 
+use App\Http\Controllers\Api\CsrfTokenController;
 use App\Http\Controllers\Api\Ajax\AvatarController;
 use App\Http\Controllers\Api\Ajax\CallseedController;
 use App\Http\Controllers\Api\Ajax\ChangeTorrentController;
@@ -41,6 +42,8 @@ use TorrentPier\Router\Router;
  * @param Router $router
  */
 return static function (Router $router): void {
+    $router->get('/api/csrf', CsrfTokenController::class);
+
     $router->group('/api/ajax', function (RouteGroup $group) {
         // Guest
         $group->post('/view-post', ViewPostController::class);

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,7 +8,6 @@
  * @license   https://github.com/torrentpier/torrentpier/blob/master/LICENSE MIT License
  */
 
-use App\Http\Controllers\Api\CsrfTokenController;
 use App\Http\Controllers\Api\Ajax\AvatarController;
 use App\Http\Controllers\Api\Ajax\CallseedController;
 use App\Http\Controllers\Api\Ajax\ChangeTorrentController;
@@ -32,6 +31,7 @@ use App\Http\Controllers\Api\Ajax\TopicTplController;
 use App\Http\Controllers\Api\Ajax\UserRegisterController;
 use App\Http\Controllers\Api\Ajax\ViewPostController;
 use App\Http\Controllers\Api\Ajax\ViewTorrentController;
+use App\Http\Controllers\Api\CsrfTokenController;
 use App\Http\Middleware\Api\EnsureRole;
 use TorrentPier\Router\RouteGroup;
 use TorrentPier\Router\Router;

--- a/src/Http/Csrf.php
+++ b/src/Http/Csrf.php
@@ -15,7 +15,8 @@ namespace TorrentPier\Http;
 use Illuminate\Support\Str;
 
 /**
- * Per-session CSRF token store keyed on session_id and persisted in bb_cache.
+ * CSRF token store persisted in bb_cache. Keyed on the stable cookie sid
+ * for logged-in users, with an sha1(ip|user-agent) fallback for guests.
  */
 final class Csrf
 {
@@ -92,7 +93,9 @@ final class Csrf
 
         // Guests have no persistent sid; the DB session_id rotates after the
         // 180s userdata cache (auth.sessions.update_interval), so derive a
-        // per-browser key from IP+UA instead.
+        // per-browser key from IP+UA instead. Tradeoff: guests behind the
+        // same NAT with identical UA share one token; acceptable because
+        // guest POST endpoints are read-only or low-privilege.
         $ip = \defined('USER_IP') && USER_IP !== '' ? (string)USER_IP : (string)(request()->getClientIp() ?? '');
         if ($ip === '') {
             return null;

--- a/src/Http/Csrf.php
+++ b/src/Http/Csrf.php
@@ -84,18 +84,22 @@ final class Csrf
 
     private static function cacheKey(): ?string
     {
-        $userdata = userdata() ?: null;
-        if (!$userdata) {
-            return null;
-        }
-        // Always key on session_id: User::session_create() issues one for guests too,
-        // so per-browser isolation works without sharing tokens behind NAT.
-        $identifier = (string)($userdata['session_id'] ?? '');
-        if ($identifier === '') {
-            return null;
+        // Logged-in: stable cookie sid survives session_create() rotations.
+        $sid = (string)(user()->sessiondata['sid'] ?? '');
+        if ($sid !== '') {
+            return self::CACHE_PREFIX . $sid;
         }
 
-        return self::CACHE_PREFIX . $identifier;
+        // Guests have no persistent sid; the DB session_id rotates after the
+        // 180s userdata cache (auth.sessions.update_interval), so derive a
+        // per-browser key from IP+UA instead.
+        $ip = \defined('USER_IP') && USER_IP !== '' ? (string)USER_IP : (string)(request()->getClientIp() ?? '');
+        if ($ip === '') {
+            return null;
+        }
+        $ua = (string)(request()->getUserAgent() ?? '');
+
+        return self::CACHE_PREFIX . 'guest_' . sha1($ip . '|' . $ua);
     }
 
     private static function ttl(): int


### PR DESCRIPTION
## Summary

Users were reporting AJAX failures with a `419 Internal Server Error` plate after sitting on a page for 3-4 minutes, even though the configured CSRF TTL is 14 days. Root cause: `Csrf::cacheKey()` was keyed on `userdata['session_id']`, which `User::session_create()` rotates whenever the 180s userdata cache (`auth.sessions.update_interval`) recycles or the IP-mismatch / 2FA reauth paths fire — Codex traced the exact paths in `src/Legacy/Common/User.php:170-230` and `211-227`.

Three coordinated changes:

- **Server (`src/Http/Csrf.php`)**: switch `cacheKey()` to the stable cookie sid for logged-in users, with an `sha1(ip|user-agent)` fallback for guests so the key survives the userdata cache cycle.
- **Refresh endpoint**: new `GET /api/csrf` returning `{token}` as JSON with `Cache-Control: no-store`. GET is exempt from the CSRF middleware so it composes cleanly with the existing stack.
- **Front-end (`public/assets/js/main.js`)**: jQuery `ajaxError` interceptor that on 419 calls the refresh endpoint, updates `_csrfToken`, the meta tag and any `_token` inputs, and retries the original request once (lock prevents thundering herd if several AJAX 419 at once). If the retry also fails, the legacy "419 Internal Server Error" plate is replaced with a clean **"Session expired. Please reload the page to continue."**

## Manual verification (Playwright on tp.test)

Tested against both `members/admin.2` profile contexts:

- [x] Guest profile view: sabotaged `X-CSRF-Token` header on `index-data` POST → first request 419, refresh fetched a new token, retry returned 200, error plate never shown.
- [x] Logged-in admin: same sabotage on `change-user-rank` POST → 419 → refresh → 200, plate never shown.
- [x] Forced double failure (second retry also 419): plate displays `Session expired. Please reload the page to continue.` instead of `419 Internal Server Error`.
- [x] Normal AJAX (valid token) still 200, no extra `/api/csrf` round-trip.
- [x] `GET /api/csrf` returns stable token per IP+UA for guests and per session sid for logged-in users.

## Out of scope

- Establishing a persistent cookie sid for guests (would change the session model significantly and is unnecessary now that the cache key is stable).
- Reworking the legacy `ajax.exec` stack to support PSR-7 conventions.

## Test plan

- [ ] CI green
- [ ] Verify on staging: idle a logged-in session for 5+ minutes, then trigger an inline-edit / group-membership AJAX. Expected: action succeeds silently, no 419 plate.
- [ ] Verify on staging: in DevTools force the token to garbage and click a profile AJAX action twice. First click silently recovers; second click after manually killing `/api/csrf` shows the Session-expired plate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)