### PR TITLE
fix(info): render inner .twig partials through Twig

### DIFF
--- a/app/Http/Controllers/info.php
+++ b/app/Http/Controllers/info.php
@@ -9,7 +9,6 @@
  */
 
 $info = [];
-$htmlDir = LANG_DIR . 'html/';
 $show = request()->getString('show');
 
 switch ($show) {
@@ -35,9 +34,11 @@ switch ($show) {
         break;
 }
 
-$require = files()->isFile($htmlDir . $info['src']) ? ($htmlDir . $info['src']) : false;
+$twig = template()->getTwig();
+$templateName = '@lang/' . $info['src'];
+$require = $twig->getLoader()->exists($templateName) ? $twig->render($templateName) : __('NOT_FOUND');
 
 print_page('info.twig', 'simple', variables: [
     'PAGE_TITLE' => mb_strtoupper($info['title'], DEFAULT_CHARSET),
-    'REQUIRE' => $require ? files()->get($require) : __('NOT_FOUND'),
+    'REQUIRE' => $require,
 ]);


### PR DESCRIPTION
## Summary
- `advert.twig` / `copyright_holders.twig` contain `{{ config('mail.addresses.*') }}` expressions but were read with `files()->get()` and inlined into `info.twig` as a raw string via `{{ REQUIRE|raw }}`. Twig does not re-parse interpolated values, so the expressions rendered as literal placeholder text on `/info?show=advert` and `/info?show=copyright_holders`.
- Regression introduced in #2282 — the partials were renamed `.html` → `.twig` and gained Twig expressions, but the controller kept loading them as raw text.
- Fix routes the partial through the `@lang` Twig namespace (already pointing at `LANG_DIR/html` in `TwigEnvironmentFactory::create()`), so inner expressions are evaluated before the HTML is passed into `info.twig`.

## Test plan
- [ ] Visit `/info?show=advert` — email address from `config('mail.addresses.advert')` renders inside the `mailto:` link and body text.
- [ ] Visit `/info?show=copyright_holders` — both occurrences of `config('mail.addresses.abuse')` render correctly.
- [ ] Visit `/info?show=user_agreement` — plain HTML page renders unchanged.
- [ ] Visit `/info?show=not_found` (or any unknown `show` value) — fallback text shown.
- [ ] Change the active forum language → translated partials still resolve via `@lang` namespace.

## Out of scope
`library/includes/page_header.php:179-183` still references non-existent `.html` paths for `HTML_AGREEMENT` / `HTML_COPYRIGHT` / `HTML_ADVERT` / `HTML_SIDEBAR_*` after the same #2282 migration. Those strings remain truthy so `page_footer.twig` keeps showing the links — a separate cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)