### PR TITLE
security: harden user-facing surface (SQLi, XSS, RBAC, HTTP status, hygiene)

### DIFF
--- a/app/Http/Controllers/Api/Ajax/ChangeTorStatusController.php
+++ b/app/Http/Controllers/Api/Ajax/ChangeTorStatusController.php
@@ -173,6 +173,15 @@ class ChangeTorStatusController
             return $this->error(__('MODULE_OFF'));
         }
 
+        // Only the torrent's release author or a moderator/admin may reply.
+        if (!IS_AM && (int)$tor['poster_id'] !== (int)userdata('user_id')) {
+            return $this->error(__('NOT_MODERATOR'));
+        }
+
+        if (empty($tor['checked_user_id'])) {
+            return $this->error(__('TORRENT_FAILED'));
+        }
+
         $subject = \sprintf(__('TOR_AUTH_TITLE'), $tor['topic_title']);
         $message = \sprintf(__('TOR_AUTH_MSG'), get_username($tor['checked_user_id']), make_url(TOPIC_URL . $tor['topic_id']), $tor['topic_title']);
 

--- a/app/Http/Controllers/Api/Ajax/ChangeUserRankController.php
+++ b/app/Http/Controllers/Api/Ajax/ChangeUserRankController.php
@@ -41,14 +41,17 @@ class ChangeUserRankController
             $ranks = datastore()->get('ranks');
         }
 
-        $rankId = (int)($body['rank_id'] ?? 0);
-        $userId = (int)($body['user_id'] ?? 0);
+        if (!isset($body['rank_id']) || !is_numeric($body['rank_id'])) {
+            return $this->error('invalid rank_id');
+        }
+        $rankId = (int)$body['rank_id'];
+        $userId = isset($body['user_id']) && is_numeric($body['user_id']) ? (int)$body['user_id'] : 0;
 
         if (!$userId || !get_userdata($userId)) {
             return $this->error(__('NO_USER_ID_SPECIFIED'));
         }
 
-        if ($rankId != 0 && !isset($ranks[$rankId])) {
+        if ($rankId !== 0 && !isset($ranks[$rankId])) {
             return $this->error("invalid rank_id: $rankId");
         }
 
@@ -56,7 +59,9 @@ class ChangeUserRankController
 
         Sessions::cache_rm_user_sessions($userId);
 
-        $userRank = $rankId ? '<span class="' . $ranks[$rankId]['rank_style'] . '">' . $ranks[$rankId]['rank_title'] . '</span>' : '';
+        $userRank = $rankId
+            ? '<span class="' . htmlCHR((string)$ranks[$rankId]['rank_style']) . '">' . htmlCHR((string)$ranks[$rankId]['rank_title']) . '</span>'
+            : '';
 
         return $this->response([
             'html' => $rankId ? __('AWARDED_RANK') . "<b> $userRank </b>" : __('SHOT_RANK'),

--- a/app/Http/Controllers/Api/Ajax/ModActionController.php
+++ b/app/Http/Controllers/Api/Ajax/ModActionController.php
@@ -108,8 +108,7 @@ class ModActionController
      */
     private function handleEditTopicTitle(array $body): ResponseInterface
     {
-        $topicId = (int)($body['topic_id'] ?? 0);
-        $oldTitle = get_topic_title($topicId);
+        $topicId = isset($body['topic_id']) && is_numeric($body['topic_id']) ? (int)$body['topic_id'] : 0;
         $newTitle = clean_title((string)($body['topic_title'] ?? ''));
 
         if (!$topicId) {
@@ -119,10 +118,11 @@ class ModActionController
             return $this->error(__('DONT_MESSAGE_TITLE'));
         }
 
-        $tData = DB()->fetch_row('SELECT forum_id FROM ' . BB_TOPICS . " WHERE topic_id = $topicId LIMIT 1");
+        $tData = DB()->fetch_row('SELECT topic_title, forum_id FROM ' . BB_TOPICS . " WHERE topic_id = $topicId LIMIT 1");
         if (!$tData) {
             return $this->error(__('INVALID_TOPIC_ID_DB'));
         }
+        $oldTitle = $tData['topic_title'];
 
         if ($error = $this->verifyModRights($tData['forum_id'])) {
             return $error;
@@ -167,10 +167,14 @@ class ModActionController
      */
     private function handleProfileIp(array $body): ResponseInterface
     {
-        $userId = (int)($body['user_id'] ?? 0);
-        $profiledata = get_userdata($userId);
+        $userId = isset($body['user_id']) && is_numeric($body['user_id']) ? (int)$body['user_id'] : 0;
 
         if (!$userId) {
+            return $this->error(__('NO_USER_ID_SPECIFIED'));
+        }
+
+        $profiledata = get_userdata($userId);
+        if (!$profiledata) {
             return $this->error(__('NO_USER_ID_SPECIFIED'));
         }
 

--- a/app/Http/Controllers/Api/Ajax/ViewPostController.php
+++ b/app/Http/Controllers/Api/Ajax/ViewPostController.php
@@ -36,17 +36,23 @@ class ViewPostController
     {
         $body = $request->getParsedBody() ?? [];
 
-        $postId = isset($body['post_id']) ? (int)$body['post_id'] : null;
-        $topicId = isset($body['topic_id']) ? (int)$body['topic_id'] : null;
+        $postId = isset($body['post_id']) && is_numeric($body['post_id']) ? (int)$body['post_id'] : null;
+        $topicId = isset($body['topic_id']) && is_numeric($body['topic_id']) ? (int)$body['topic_id'] : null;
         $returnText = config()->get('forum.show_post_bbcode_button.enabled')
             && isset($body['return_text'])
             && $body['return_text'];
 
         if ($postId === null) {
+            if (!$topicId) {
+                return $this->error(__('TOPIC_POST_NOT_EXIST'));
+            }
             $postId = DB()->fetch_row(
-                'SELECT topic_first_post_id FROM ' . BB_TOPICS . " WHERE topic_id = $topicId",
+                'SELECT topic_first_post_id FROM ' . BB_TOPICS . " WHERE topic_id = {$topicId}",
                 'topic_first_post_id',
             );
+            if (!$postId) {
+                return $this->error(__('TOPIC_POST_NOT_EXIST'));
+            }
         }
 
         $postTextSql = $returnText
@@ -84,7 +90,7 @@ class ViewPostController
 
         $response = [
             'post_id' => $postId,
-            'topic_id' => $topicId,
+            'topic_id' => $topicId ?? (int)$postData['topic_id'],
         ];
 
         if ($returnText) {

--- a/app/Http/Controllers/dl.php
+++ b/app/Http/Controllers/dl.php
@@ -17,7 +17,7 @@ $m3u = request()->getBool('m3u');
 set_die_append_msg();
 
 if (!$topic_id) {
-    bb_die(__('NO_ATTACHMENT_SELECTED'));
+    bb_die(__('NO_ATTACHMENT_SELECTED'), 400);
 }
 
 // Get topic data with torrent info
@@ -32,11 +32,11 @@ $sql = '
 ";
 
 if (!$t_data = DB()->fetch_row($sql)) {
-    bb_die(__('ERROR_NO_ATTACHMENT') . '[DB]');
+    bb_die(__('ERROR_NO_ATTACHMENT') . '[DB]', 404);
 }
 
 if (!$t_data['attach_ext_id']) {
-    bb_die(__('ERROR_NO_ATTACHMENT') . '[EXT_ID]');
+    bb_die(__('ERROR_NO_ATTACHMENT') . '[EXT_ID]', 404);
 }
 
 $forum_id = $t_data['forum_id'];
@@ -53,7 +53,7 @@ if (!$is_auth['auth_download']) {
 if ($m3u) {
     $torrServer = new TorrentPier\TorrServerAPI;
     if (!$m3uFile = $torrServer->getM3UPath($topic_id)) {
-        bb_die(__('ERROR_NO_ATTACHMENT') . '[M3U]');
+        bb_die(__('ERROR_NO_ATTACHMENT') . '[M3U]', 404);
     }
 
     $response = Response::download($m3uFile, basename($m3uFile));
@@ -65,14 +65,14 @@ if ($m3u) {
 // Check tor status for frozen downloads
 if (!IS_AM && $t_data['tor_status']) {
     if (isset(config()->get('tracker.tor_frozen')[$t_data['tor_status']]) && !(isset(config()->get('tracker.tor_frozen_author_download')[$t_data['tor_status']]) && TorrentPier\Topic\Guard::isAuthor($t_data['poster_id']))) {
-        bb_die(__('TOR_STATUS_FORBIDDEN') . __('TOR_STATUS_NAME.' . $t_data['tor_status']));
+        bb_die(__('TOR_STATUS_FORBIDDEN') . __('TOR_STATUS_NAME.' . $t_data['tor_status']), 403);
     }
 }
 
 // Check download limit
 $dlCounter = new TorrentPier\Torrent\DownloadCounter;
 if (!$dlCounter->recordDownload($topic_id, userdata('user_id'), IS_PREMIUM)) {
-    bb_die(__('DOWNLOAD_LIMIT_EXCEEDED'));
+    bb_die(__('DOWNLOAD_LIMIT_EXCEEDED'), 429);
 }
 
 // For torrents - add a passkey and send
@@ -87,7 +87,7 @@ if ($t_data['attach_ext_id'] == TORRENT_EXT_ID) {
 $file_path = TorrentPier\Attachment::getPath($topic_id);
 
 if (!files()->isFile($file_path)) {
-    bb_die(__('ERROR_NO_ATTACHMENT') . ' [HDD]');
+    bb_die(__('ERROR_NO_ATTACHMENT') . ' [HDD]', 404);
 }
 
 $ext = FileExtensions::getExtension($t_data['attach_ext_id']) ?? '';

--- a/app/Http/Controllers/feed.php
+++ b/app/Http/Controllers/feed.php
@@ -16,12 +16,12 @@ use TorrentPier\Http\Response;
 
 // Get request parameters
 $type = request()->query->get('type', '');
-$id = request()->getInt('id');
+$idRaw = (string)request()->query->get('id', '');
 
-// Validate type and ID
-if (!in_array($type, ['f', 'u'], true) || $id < 0) {
+if (!in_array($type, ['f', 'u'], true) || !ctype_digit($idRaw)) {
     bb_simple_die(__('ATOM_ERROR'));
 }
+$id = (int)$idRaw;
 
 try {
     $generator = app(FeedGenerator::class);

--- a/app/Http/Controllers/memberlist.php
+++ b/app/Http/Controllers/memberlist.php
@@ -100,10 +100,11 @@ $orderColumn = match ($mode) {
     default => 'user_regdate',
 };
 $limit = $mode === 'topten' ? 10 : config()->get('topics_per_page');
+$effective_sort_order = $mode === 'topten' ? 'DESC' : $sort_order;
 
 $result = (clone $query)
     ->select(['username', 'user_id', 'user_rank', 'user_opt', 'user_posts', 'user_regdate', 'user_from', 'user_website', 'user_email', 'avatar_ext_id'])
-    ->orderBy($orderColumn, $sort_order)
+    ->orderBy($orderColumn, $effective_sort_order)
     ->offset($mode === 'topten' ? 0 : $start)
     ->limit($limit)
     ->toBase()

--- a/app/Http/Controllers/modcp.php
+++ b/app/Http/Controllers/modcp.php
@@ -35,6 +35,10 @@
  * ===========================================================================
  */
 
+// Modes that mutate state without a confirmation step. Requests for these
+// must arrive via POST so the CSRF middleware is exercised.
+const MODCP_IMMEDIATE_MODES = ['lock', 'unlock', 'post_pin', 'post_unpin', 'set_download', 'unset_download'];
+
 //
 // Functions
 //
@@ -117,6 +121,10 @@ if (request()->has('mode')) {
     }
 }
 
+if (in_array($mode, MODCP_IMMEDIATE_MODES, true) && !request()->isPost()) {
+    bb_die('Method Not Allowed', 405);
+}
+
 // Obtain relevant data
 if ($topic_id) {
     $sql = '
@@ -130,7 +138,7 @@ if ($topic_id) {
 	";
 
     if (!$topic_row = DB()->fetch_row($sql)) {
-        bb_die(__('INVALID_TOPIC_ID_DB'));
+        bb_die(__('INVALID_TOPIC_ID_DB'), 404);
     }
 
     $forum_id = $topic_row['forum_id'];
@@ -140,13 +148,13 @@ if ($topic_id) {
     $sql = 'SELECT forum_name, forum_topics FROM ' . BB_FORUMS . " WHERE forum_id = {$forum_id} LIMIT 1";
 
     if (!$topic_row = DB()->fetch_row($sql)) {
-        bb_die(__('FORUM_NOT_EXIST'));
+        bb_die(__('FORUM_NOT_EXIST'), 404);
     }
 
     $forum_name = $topic_row['forum_name'];
     $forum_topics = (!$topic_row['forum_topics']) ? 1 : $topic_row['forum_topics'];
 } else {
-    bb_die('Invalid request');
+    bb_die('Invalid request', 400);
 }
 
 // Check if user did or did not confirm. If they did not, forward them to the last page they were on
@@ -179,7 +187,7 @@ if ($mode == 'ip') {
 
 // Exit if user not authorized
 if (!$is_auth['auth_mod']) {
-    bb_die(__('NOT_MODERATOR'));
+    bb_die(__('NOT_MODERATOR'), 403);
 }
 
 // Redirect to login page if not admin session

--- a/app/Http/Controllers/posting.php
+++ b/app/Http/Controllers/posting.php
@@ -74,7 +74,7 @@ switch ($mode) {
     case 'newtopic':
     case 'new_rel':
         if (bf(userdata('user_opt'), 'user_opt', 'dis_topic')) {
-            bb_die(__('RULES_POST_CANNOT'));
+            bb_die(__('RULES_POST_CANNOT'), 403);
         }
         if ($topic_type == POST_ANNOUNCE) {
             $is_auth_type = 'auth_announce';
@@ -88,14 +88,14 @@ switch ($mode) {
     case 'reply':
     case 'quote':
         if (bf(userdata('user_opt'), 'user_opt', 'dis_post')) {
-            bb_die(__('RULES_REPLY_CANNOT'));
+            bb_die(__('RULES_REPLY_CANNOT'), 403);
         }
         $is_auth_type = 'auth_reply';
         break;
 
     case 'editpost':
         if (bf(userdata('user_opt'), 'user_opt', 'dis_post_edit')) {
-            bb_die(__('RULES_EDIT_CANNOT'));
+            bb_die(__('RULES_EDIT_CANNOT'), 403);
         }
         $is_auth_type = 'auth_edit';
         break;
@@ -123,7 +123,7 @@ switch ($mode) {
 
     case 'reply':
         if (!$topic_id) {
-            bb_die(__('NO_TOPIC_ID'));
+            bb_die(__('NO_TOPIC_ID'), 400);
         }
         $sql = 'SELECT f.*, t.*
 			FROM ' . BB_FORUMS . ' f, ' . BB_TOPICS . " t
@@ -171,9 +171,9 @@ if ($post_info = DB()->fetch_row($sql)) {
     $is_auth = auth(AUTH_ALL, $forum_id, userdata(), $post_info);
 
     if ($post_info['forum_status'] == FORUM_LOCKED && !$is_auth['auth_mod']) {
-        bb_die(__('FORUM_LOCKED'));
+        bb_die(__('FORUM_LOCKED'), 403);
     } elseif ($mode != 'newtopic' && $mode != 'new_rel' && $post_info['topic_status'] == TOPIC_LOCKED && !$is_auth['auth_mod']) {
-        bb_die(__('TOPIC_LOCKED'));
+        bb_die(__('TOPIC_LOCKED'), 403);
     }
 
     if ($mode == 'editpost' || $mode == 'delete') {
@@ -210,7 +210,8 @@ if ($post_info = DB()->fetch_row($sql)) {
         $post_data['last_post'] = false;
     }
 } else {
-    bb_die(__('NO_SUCH_POST'));
+    $missingKey = ($mode === 'newtopic' || $mode === 'new_rel') ? 'FORUM_NOT_EXIST' : 'NO_SUCH_POST';
+    bb_die(__($missingKey), 404);
 }
 
 // The user is not authed, if they're not logged in then redirect

--- a/app/Http/Controllers/privmsg.php
+++ b/app/Http/Controllers/privmsg.php
@@ -127,7 +127,7 @@ if ($mode == 'read') {
     if (request()->query->has(POST_POST_URL)) {
         $privmsgs_id = request()->query->getInt(POST_POST_URL);
     } else {
-        bb_die(__('NO_PM_ID'));
+        bb_die(__('NO_PM_ID'), 400);
     }
 
     switch ($folder) {
@@ -158,7 +158,7 @@ if ($mode == 'read') {
 				)';
             break;
         default:
-            bb_die(__('NO_SUCH_FOLDER'));
+            bb_die(__('NO_SUCH_FOLDER'), 404);
             break;
     }
 
@@ -599,7 +599,7 @@ if ($mode == 'read') {
 
             pm_die(__('DELETE_POSTS_SUCCESFULLY'));
         } else {
-            pm_die(__('NONE_SELECTED'));
+            pm_die(__('NONE_SELECTED'), 400);
         }
     }
 } elseif ($save && $mark_list && $folder != 'savebox' && $folder != 'outbox') {
@@ -762,7 +762,7 @@ if ($mode == 'read') {
             $current_time = TIMENOW;
 
             if (($current_time - $last_post_time) < config()->get('flood_interval')) {
-                bb_die(__('FLOOD_ERROR'));
+                bb_die(__('FLOOD_ERROR'), 429);
             }
         }
     }
@@ -778,7 +778,7 @@ if ($mode == 'read') {
         }
 
         if (!($row = DB()->sql_fetchrow($result))) {
-            bb_die(__('NO_SUCH_POST'));
+            bb_die(__('NO_SUCH_POST'), 404);
         }
         DB()->sql_freeresult($result);
 
@@ -828,7 +828,7 @@ if ($mode == 'read') {
         // Has admin prevented user from sending PM's?
         //
         if (bf(userdata('user_opt'), 'user_opt', 'dis_pm')) {
-            bb_die(__('CANNOT_SEND_PRIVMSG'));
+            bb_die(__('CANNOT_SEND_PRIVMSG'), 403);
         }
 
         $msg_time = TIMENOW;
@@ -842,7 +842,7 @@ if ($mode == 'read') {
 						OR privmsgs_type = ' . PRIVMSGS_UNREAD_MAIL . ' )
 					AND privmsgs_to_userid = ' . $to_userdata['user_id'];
             if (!($result = DB()->sql_query($sql))) {
-                bb_die(__('NO_SUCH_USER'));
+                bb_die(__('NO_SUCH_USER'), 404);
             }
 
             if ($inbox_info = DB()->sql_fetchrow($result)) {
@@ -879,7 +879,7 @@ if ($mode == 'read') {
                     ['type' => 'pm', 'ip' => CLIENT_IP, 'subject' => $privmsg_subject, 'username' => userdata('username')],
                 );
                 if ($contentResult->isDenied()) {
-                    bb_die(__('PM_SPAM_DENIED'));
+                    bb_die(__('PM_SPAM_DENIED'), 429);
                 }
             }
 
@@ -973,13 +973,13 @@ if ($mode == 'read') {
 
             if ($postrow = DB()->sql_fetchrow($result)) {
                 if (userdata('user_id') != $postrow['user_id']) {
-                    bb_die(__('EDIT_OWN_POSTS'));
+                    bb_die(__('EDIT_OWN_POSTS'), 403);
                 }
             }
         }
     } else {
         if (!$privmsg_id && ($mode == 'reply' || $mode == 'edit' || $mode == 'quote')) {
-            bb_die(__('NO_POST_ID'));
+            bb_die(__('NO_POST_ID'), 400);
         }
 
         if (request()->query->has(POST_USERS_URL)) {
@@ -1256,7 +1256,7 @@ if ($mode == 'read') {
             break;
 
         default:
-            bb_die(__('NO_SUCH_FOLDER'));
+            bb_die(__('NO_SUCH_FOLDER'), 404);
             break;
     }
 
@@ -1456,7 +1456,7 @@ require PAGE_FOOTER;
 //
 // Functions
 //
-function pm_die($msg)
+function pm_die($msg, int $statusCode = 200)
 {
     $msg .= '<br /><br />';
     $msg .= sprintf(__('CLICK_RETURN_INBOX'), '<a href="' . PM_URL . '?folder=inbox">', '</a> ');
@@ -1466,5 +1466,5 @@ function pm_die($msg)
     $msg .= '<br /><br />';
     $msg .= sprintf(__('CLICK_RETURN_INDEX'), '<a href="index.php">', '</a>');
 
-    bb_die($msg);
+    bb_die($msg, $statusCode);
 }

--- a/app/Http/Controllers/search.php
+++ b/app/Http/Controllers/search.php
@@ -447,6 +447,20 @@ $title_match = ($text_match_sql && ($params->val('title_only') || config()->get(
 // "Display as" mode (posts or topics)
 $post_mode = (!$dl_search && ($params->val('display_as') == $as_posts || request()->query->has('search_author')));
 
+// Require at least one user-supplied filter — otherwise an empty submission would
+// dump the entire forum.
+$has_user_criteria = $text_match_sql
+    || $params->val('poster_id')
+    || $params->val('forum')
+    || $params->val('topic')
+    || $prev_days
+    || $dl_search
+    || $new_posts
+    || $new_topics;
+if (!$items_found && !$has_user_criteria) {
+    redirect($url);
+}
+
 // Start building SQL
 $SQL = DB()->get_empty_sql_array();
 
@@ -1004,21 +1018,27 @@ function username_search($search_match)
     if (!empty($search_match)) {
         $username_search = str_replace('*', '%', clean_username($search_match));
 
-        $sql = '
-			SELECT username
-			FROM ' . BB_USERS . "
-			WHERE username LIKE '" . DB()->escape($username_search) . "'
-				AND user_id <> " . GUEST_UID . '
-			ORDER BY username
-			LIMIT 200
-		';
-
-        foreach (DB()->fetch_rowset($sql) as $row) {
-            $username = htmlCHR(stripslashes(html_entity_decode($row['username'])));
-            $username_list .= '<option value="' . $username . '">' . $username . '</option>';
-        }
-        if (!$username_list) {
+        // Require at least two literal characters to avoid dumping the whole user list with bare wildcards.
+        $literal = preg_replace('/[%_]/u', '', $username_search);
+        if (mb_strlen($literal, 'UTF-8') < 2) {
             $username_list = '<option value="">' . __('NO_MATCH') . '</option>';
+        } else {
+            $sql = '
+				SELECT username
+				FROM ' . BB_USERS . "
+				WHERE username LIKE '" . DB()->escape($username_search) . "'
+					AND user_id <> " . GUEST_UID . '
+				ORDER BY username
+				LIMIT 200
+			';
+
+            foreach (DB()->fetch_rowset($sql) as $row) {
+                $username = htmlCHR(stripslashes(html_entity_decode($row['username'])));
+                $username_list .= '<option value="' . $username . '">' . $username . '</option>';
+            }
+            if (!$username_list) {
+                $username_list = '<option value="">' . __('NO_MATCH') . '</option>';
+            }
         }
     }
 

--- a/app/Http/Controllers/tracker.php
+++ b/app/Http/Controllers/tracker.php
@@ -70,7 +70,7 @@ $lastvisit = (!IS_GUEST) ? userdata('user_lastvisit') : '';
 $search_id = (request()->query->has('search_id') && verify_id(request()->query->get('search_id'), SEARCH_ID_LENGTH)) ? request()->query->get('search_id') : '';
 $session_id = userdata('session_id');
 
-$status = request()->getArray('status');
+$status = array_map('intval', request()->getArray('status'));
 
 $cat_forum = $tor_to_show = $search_in_forums_ary = [];
 $title_match_sql = $title_match_q = $search_in_forums_csv = '';

--- a/app/Http/Controllers/viewforum.php
+++ b/app/Http/Controllers/viewforum.php
@@ -64,7 +64,7 @@ caching_output(IS_GUEST, 'send', REQUESTED_PAGE . '_guest');
 set_die_append_msg();
 $forums = forum_tree();
 if (!$forum_id || !$forum_data = @$forums['forum'][$forum_id]) {
-    bb_die(__('FORUM_NOT_EXIST'));
+    bb_die(__('FORUM_NOT_EXIST'), 404);
 }
 
 // Set meta description
@@ -146,7 +146,7 @@ $show_subforums = !config()->get('forum.sf_on_first_page_only') || !$start;
 $forums = forum_tree();
 
 if ($forums['forum'][$forum_id]['allow_porno_topic'] && bf(userdata('user_opt'), 'user_opt', 'user_porn_forums')) {
-    bb_die(__('ERROR_PORNO_FORUM'));
+    bb_die(__('ERROR_PORNO_FORUM'), 403);
 }
 
 if (!$forum_data['forum_parent'] && isset($forums['f'][$forum_id]['subforums']) && $show_subforums) {

--- a/app/Http/Controllers/viewtopic.php
+++ b/app/Http/Controllers/viewtopic.php
@@ -132,7 +132,7 @@ $topic_id = $t_data['topic_id'];
 $forum_id = $t_data['forum_id'];
 
 if ($t_data['allow_porno_topic'] && bf(userdata('user_opt'), 'user_opt', 'user_porn_forums')) {
-    bb_die(__('ERROR_PORNO_FORUM'));
+    bb_die(__('ERROR_PORNO_FORUM'), 403);
 }
 
 if (userdata('session_admin') && request()->has('mod')) {
@@ -383,7 +383,7 @@ if ($postrow = DB()->fetch_rowset($sql)) {
     }
     $total_posts = count($postrow);
 } else {
-    bb_die(__('NO_POSTS_TOPIC'));
+    bb_die(__('NO_POSTS_TOPIC'), 404);
 }
 
 if (!$ranks = datastore()->get('ranks')) {

--- a/app/Http/Controllers/viewtopic.php
+++ b/app/Http/Controllers/viewtopic.php
@@ -419,22 +419,39 @@ $s_auth_can .= (($is_auth['auth_download']) ? __('RULES_DOWNLOAD_CAN') : __('RUL
 
 // Moderator output
 $topic_mod = '';
+// Confirmation-form modes (delete/move/split) stay as GET links; the controller renders a confirm screen.
+$modcp_link = static function (string $mode, string $image, string $title) use ($topic_id): string {
+    return '<a href="' . FORUM_PATH . 'modcp?' . POST_TOPIC_URL . "={$topic_id}&amp;mode={$mode}&amp;sid=" . userdata('session_id') . '"><img src="' . theme_images($image) . '" alt="' . $title . '" title="' . $title . '" border="0" /></a>';
+};
+// Immediate-mutation modes (lock/unlock/set_download/unset_download/post_pin/post_unpin) require POST + CSRF.
+$modcp_form = static function (string $mode, string $image, string $title) use ($topic_id): string {
+    $token = htmlspecialchars(\TorrentPier\Http\Csrf::token(), ENT_QUOTES);
+    return '<form action="' . FORUM_PATH . 'modcp" method="post" style="display:inline">'
+        . '<input type="hidden" name="' . \TorrentPier\Http\Csrf::FIELD . '" value="' . $token . '">'
+        . '<input type="hidden" name="' . POST_TOPIC_URL . '" value="' . (int)$topic_id . '">'
+        . '<input type="hidden" name="mode" value="' . $mode . '">'
+        . '<input type="image" src="' . theme_images($image) . '" alt="' . $title . '" title="' . $title . '" border="0">'
+        . '</form>';
+};
+
 if ($is_auth['auth_mod']) {
     $s_auth_can .= __('RULES_MODERATE');
-    $topic_mod .= '<a href="' . FORUM_PATH . 'modcp?' . POST_TOPIC_URL . "={$topic_id}&amp;mode=delete&amp;sid=" . userdata('session_id') . '"><img src="' . theme_images('topic_mod_delete') . '" alt="' . __('DELETE_TOPIC') . '" title="' . __('DELETE_TOPIC') . '" border="0" /></a>&nbsp;';
-    $topic_mod .= '<a href="' . FORUM_PATH . 'modcp?' . POST_TOPIC_URL . "={$topic_id}&amp;mode=move&amp;sid=" . userdata('session_id') . '"><img src="' . theme_images('topic_mod_move') . '" alt="' . __('MOVE_TOPIC') . '" title="' . __('MOVE_TOPIC') . '" border="0" /></a>&nbsp;';
-    $topic_mod .= ($t_data['topic_status'] == TOPIC_UNLOCKED) ? '<a href="' . FORUM_PATH . 'modcp?' . POST_TOPIC_URL . "={$topic_id}&amp;mode=lock&amp;sid=" . userdata('session_id') . '"><img src="' . theme_images('topic_mod_lock') . '" alt="' . __('LOCK_TOPIC') . '" title="' . __('LOCK_TOPIC') . '" border="0" /></a>&nbsp;' : '<a href="' . FORUM_PATH . 'modcp?' . POST_TOPIC_URL . "={$topic_id}&amp;mode=unlock&amp;sid=" . userdata('session_id') . '"><img src="' . theme_images('topic_mod_unlock') . '" alt="' . __('UNLOCK_TOPIC') . '" title="' . __('UNLOCK_TOPIC') . '" border="0" /></a>&nbsp;';
-    $topic_mod .= '<a href="' . FORUM_PATH . 'modcp?' . POST_TOPIC_URL . "={$topic_id}&amp;mode=split&amp;sid=" . userdata('session_id') . '"><img src="' . theme_images('topic_mod_split') . '" alt="' . __('SPLIT_TOPIC') . '" title="' . __('SPLIT_TOPIC') . '" border="0" /></a>&nbsp;';
+    $topic_mod .= $modcp_link('delete', 'topic_mod_delete', __('DELETE_TOPIC')) . '&nbsp;';
+    $topic_mod .= $modcp_link('move', 'topic_mod_move', __('MOVE_TOPIC')) . '&nbsp;';
+    $topic_mod .= ($t_data['topic_status'] == TOPIC_UNLOCKED)
+        ? $modcp_form('lock', 'topic_mod_lock', __('LOCK_TOPIC')) . '&nbsp;'
+        : $modcp_form('unlock', 'topic_mod_unlock', __('UNLOCK_TOPIC')) . '&nbsp;';
+    $topic_mod .= $modcp_link('split', 'topic_mod_split', __('SPLIT_TOPIC')) . '&nbsp;';
 
     if ($t_data['allow_reg_tracker'] || $t_data['topic_dl_type'] == TOPIC_DL_TYPE_DL || IS_ADMIN) {
         if ($t_data['topic_dl_type'] == TOPIC_DL_TYPE_DL) {
-            $topic_mod .= '<a href="' . FORUM_PATH . 'modcp?' . POST_TOPIC_URL . "={$topic_id}&amp;mode=unset_download&amp;sid=" . userdata('session_id') . '"><img src="' . theme_images('topic_normal') . '" alt="' . __('UNSET_DL_STATUS') . '" title="' . __('UNSET_DL_STATUS') . '" border="0" /></a>';
+            $topic_mod .= $modcp_form('unset_download', 'topic_normal', __('UNSET_DL_STATUS'));
         } else {
-            $topic_mod .= '<a href="' . FORUM_PATH . 'modcp?' . POST_TOPIC_URL . "={$topic_id}&amp;mode=set_download&amp;sid=" . userdata('session_id') . '"><img src="' . theme_images('topic_dl') . '" alt="' . __('SET_DL_STATUS') . '" title="' . __('SET_DL_STATUS') . '" border="0" /></a>';
+            $topic_mod .= $modcp_form('set_download', 'topic_dl', __('SET_DL_STATUS'));
         }
     }
 } elseif (!IS_GUEST && ($t_data['topic_poster'] == userdata('user_id')) && $t_data['self_moderated']) {
-    $topic_mod .= '<a href="' . FORUM_PATH . 'modcp?' . POST_TOPIC_URL . "={$topic_id}&amp;mode=move&amp;sid=" . userdata('session_id') . '"><img src="' . theme_images('topic_mod_move') . '" alt="' . __('MOVE_TOPIC') . '" title="' . __('MOVE_TOPIC') . '" border="0" /></a>&nbsp;';
+    $topic_mod .= $modcp_link('move', 'topic_mod_move', __('MOVE_TOPIC')) . '&nbsp;';
 }
 
 // Topic watch information
@@ -529,7 +546,6 @@ template()->assign_vars([
     'HIDE_RANK_IMG_DIS' => !config()->get('forum.show_rank_image'),
 
     'PINNED_FIRST_POST' => $t_data['topic_show_first_post'],
-    'PIN_HREF' => $t_data['topic_show_first_post'] ? FORUM_PATH . 'modcp?' . POST_TOPIC_URL . "={$topic_id}&amp;mode=post_unpin" : FORUM_PATH . 'modcp?' . POST_TOPIC_URL . "={$topic_id}&amp;mode=post_pin",
     'PIN_TITLE' => $t_data['topic_show_first_post'] ? __('POST_UNPIN') : __('POST_PIN'),
 
     'AUTH_MOD' => $is_auth['auth_mod'],

--- a/app/Http/Controllers/viewtopic.php
+++ b/app/Http/Controllers/viewtopic.php
@@ -425,9 +425,10 @@ $modcp_link = static function (string $mode, string $image, string $title) use (
 };
 // Immediate-mutation modes (lock/unlock/set_download/unset_download/post_pin/post_unpin) require POST + CSRF.
 $modcp_form = static function (string $mode, string $image, string $title) use ($topic_id): string {
-    $token = htmlspecialchars(\TorrentPier\Http\Csrf::token(), ENT_QUOTES);
+    $token = htmlspecialchars(TorrentPier\Http\Csrf::token(), ENT_QUOTES);
+
     return '<form action="' . FORUM_PATH . 'modcp" method="post" style="display:inline">'
-        . '<input type="hidden" name="' . \TorrentPier\Http\Csrf::FIELD . '" value="' . $token . '">'
+        . '<input type="hidden" name="' . TorrentPier\Http\Csrf::FIELD . '" value="' . $token . '">'
         . '<input type="hidden" name="' . POST_TOPIC_URL . '" value="' . (int)$topic_id . '">'
         . '<input type="hidden" name="mode" value="' . $mode . '">'
         . '<input type="image" src="' . theme_images($image) . '" alt="' . $title . '" title="' . $title . '" border="0">'

--- a/library/includes/functions.php
+++ b/library/includes/functions.php
@@ -967,19 +967,19 @@ function render_flag(string $code, bool $showName = true): string
     }
 
     if (!Countries::exists($code)) {
-        return $code;
+        return htmlCHR($code);
     }
 
     $flagIconFile = IMAGES_DIR . '/flags/' . $code . $iconExtension;
     if (!files()->isFile($flagIconFile)) {
-        return $code;
+        return htmlCHR($code);
     }
 
     $flagIconUrl = image_url('flags/' . $code . $iconExtension);
     $langName = Countries::getName($code);
     $countryName = $showName ? '&nbsp;' . str_short($langName, 20) : '';
 
-    return '<span title="' . $langName . '"><img src="' . $flagIconUrl . '" class="poster-flag" alt="' . $code . '">' . $countryName . '</span>';
+    return '<span title="' . htmlCHR($langName) . '"><img src="' . $flagIconUrl . '" class="poster-flag" alt="' . htmlCHR($code) . '">' . $countryName . '</span>';
 }
 
 function birthday_age($date)
@@ -1267,7 +1267,7 @@ function get_forum_display_sort_option($selected_row = 0, $action = 'list', $lis
 
     // init the result
     $res = '';
-    if ($selected_row > count($listrow['lang_key'])) {
+    if (!isset($listrow['fields'][$selected_row])) {
         $selected_row = 0;
     }
 
@@ -1498,11 +1498,21 @@ function clean_text_match(?string $text, bool $ltrim_star = true, bool $die_if_e
         $text = Str::squish($text);
         $text = trim($text);
     } else {
+        if (config()->get('forum.allow_search_in_bool_mode')) {
+            // Strip MySQL BOOLEAN MODE meta chars that would otherwise raise
+            // a 1064 syntax error on payloads like "<x>", "@x", "(x", etc.
+            $text = strtr($text, ['<' => ' ', '>' => ' ', '(' => ' ', ')' => ' ', '~' => ' ', '@' => ' ']);
+            // Drop unbalanced double-quotes so phrase syntax stays well-formed.
+            if (substr_count($text, '"') % 2 !== 0) {
+                $text = str_replace('"', ' ', $text);
+            }
+            $text = Str::squish($text);
+        }
         $text = DB()->escape(trim($text));
     }
 
     if (!$text && $die_if_empty) {
-        bb_die(__('NO_SEARCH_MATCH'));
+        bb_die(__('NO_SEARCH_MATCH'), 200);
     }
 
     return $text;

--- a/library/includes/ucp/activate.php
+++ b/library/includes/ucp/activate.php
@@ -9,7 +9,7 @@
  */
 
 if (!request()->query->has(POST_USERS_URL) || !request()->query->has('act_key')) {
-    bb_die('Bad request');
+    bb_die('Bad request', 400);
 }
 
 $sql = 'SELECT user_active, user_id, username, user_email, user_newpasswd, user_lang, user_actkey, user_actkey_time
@@ -19,31 +19,30 @@ if (!($result = DB()->sql_query($sql))) {
     bb_die('Could not obtain user information');
 }
 
-if ($row = DB()->sql_fetchrow($result)) {
-    $stored_actkey = trim($row['user_actkey']);
-    $supplied_actkey = trim((string)request()->query->get('act_key'));
-    $actkey_ttl = (int)config()->get('auth.actkey_ttl');
-    $actkey_expired = $actkey_ttl > 0
-        && (int)$row['user_actkey_time'] > 0
-        && (TIMENOW - (int)$row['user_actkey_time']) > $actkey_ttl;
-
-    if ($row['user_active'] && $stored_actkey === '') {
-        bb_die(__('ALREADY_ACTIVATED'));
-    } elseif ($stored_actkey !== '' && !$actkey_expired && hash_equals($stored_actkey, $supplied_actkey)) {
-        $sql_update_pass = ($row['user_newpasswd'] != '') ? ", user_password = '" . user()->password_hash($row['user_newpasswd']) . "', user_newpasswd = ''" : '';
-
-        $sql = 'UPDATE ' . BB_USERS . "
-			SET user_active = 1, user_actkey = '', user_actkey_time = 0" . $sql_update_pass . '
-			WHERE user_id = ' . $row['user_id'];
-        if (!($result = DB()->sql_query($sql))) {
-            bb_die('Could not update users table');
-        }
-
-        $message = ($sql_update_pass == '') ? __('ACCOUNT_ACTIVE') : __('PASSWORD_ACTIVATED');
-        bb_die($message);
-    } else {
-        bb_die(__('WRONG_ACTIVATION'));
-    }
-} else {
-    bb_die(__('NO_SUCH_USER'));
+$row = DB()->sql_fetchrow($result);
+if (!$row) {
+    bb_die(__('WRONG_ACTIVATION'), 400);
 }
+
+$stored_actkey = trim($row['user_actkey']);
+$supplied_actkey = trim((string)request()->query->get('act_key'));
+$actkey_ttl = (int)config()->get('auth.actkey_ttl');
+$actkey_expired = $actkey_ttl > 0
+    && (int)$row['user_actkey_time'] > 0
+    && (TIMENOW - (int)$row['user_actkey_time']) > $actkey_ttl;
+
+if ($stored_actkey !== '' && !$actkey_expired && hash_equals($stored_actkey, $supplied_actkey)) {
+    $sql_update_pass = ($row['user_newpasswd'] != '') ? ", user_password = '" . user()->password_hash($row['user_newpasswd']) . "', user_newpasswd = ''" : '';
+
+    $sql = 'UPDATE ' . BB_USERS . "
+		SET user_active = 1, user_actkey = '', user_actkey_time = 0" . $sql_update_pass . '
+		WHERE user_id = ' . $row['user_id'];
+    if (!($result = DB()->sql_query($sql))) {
+        bb_die('Could not update users table');
+    }
+
+    $message = ($sql_update_pass == '') ? __('ACCOUNT_ACTIVE') : __('PASSWORD_ACTIVATED');
+    bb_die($message, 200);
+}
+
+bb_die(__('WRONG_ACTIVATION'), 400);

--- a/library/includes/ucp/sendpasswd.php
+++ b/library/includes/ucp/sendpasswd.php
@@ -20,54 +20,45 @@ $need_captcha = (request()->query->get('mode') == 'sendpassword' && !IS_ADMIN &&
 
 if (request()->post->has('submit')) {
     if ($need_captcha && !bb_captcha('check')) {
-        bb_die(__('CAPTCHA_WRONG'));
+        bb_die(__('CAPTCHA_WRONG'), 400);
     }
     $email = (!empty(request()->post->get('email'))) ? trim(strip_tags(htmlspecialchars(request()->post->get('email')))) : '';
+
     $sql = 'SELECT * FROM ' . BB_USERS . " WHERE user_email = '" . DB()->escape($email) . "'";
-    if ($result = DB()->sql_query($sql)) {
-        if ($row = DB()->sql_fetchrow($result)) {
-            if (!$row['user_active']) {
-                bb_die(__('NO_SEND_ACCOUNT_INACTIVE'));
-            }
-            if (in_array($row['user_level'], [MOD, ADMIN])) {
-                bb_die(__('NO_SEND_ACCOUNT'));
-            }
-
-            $username = $row['username'];
-            $user_id = $row['user_id'];
-
-            $user_actkey = Str::random(ACTKEY_LENGTH);
-            $user_password = Str::random(PASSWORD_MIN_LENGTH);
-
-            $sql = 'UPDATE ' . BB_USERS . "
-				SET user_newpasswd = '{$user_password}', user_actkey = '{$user_actkey}', user_actkey_time = " . TIMENOW . '
-				WHERE user_id = ' . $row['user_id'];
-            if (!DB()->sql_query($sql)) {
-                bb_die('Could not update new password information');
-            }
-
-            // Sending email
-            $emailer = new TorrentPier\Emailer;
-
-            $emailer->set_to($row['user_email'], $username);
-            $emailer->set_subject(__('EMAILER_SUBJECT')['USER_ACTIVATE_PASSWD']);
-
-            $emailer->set_template('user_activate_passwd', $row['user_lang']);
-            $emailer->assign_vars([
-                'USERNAME' => $username,
-                'PASSWORD' => $user_password,
-                'U_ACTIVATE' => make_url(ACTIVATE_URL . $user_id . '/' . $user_actkey . '/'),
-            ]);
-
-            $emailer->send();
-
-            bb_die(__('PASSWORD_UPDATED'));
-        } else {
-            bb_die(__('NO_EMAIL_MATCH'));
-        }
-    } else {
+    if (!$result = DB()->sql_query($sql)) {
         bb_die('Could not obtain user information for sendpassword');
     }
+    $row = DB()->sql_fetchrow($result);
+
+    $eligible = $row && $row['user_active'] && !in_array($row['user_level'], [MOD, ADMIN], true);
+
+    if ($eligible) {
+        $username = $row['username'];
+        $user_id = $row['user_id'];
+
+        $user_actkey = Str::random(ACTKEY_LENGTH);
+        $user_password = Str::random(PASSWORD_MIN_LENGTH);
+
+        $sql = 'UPDATE ' . BB_USERS . "
+			SET user_newpasswd = '{$user_password}', user_actkey = '{$user_actkey}', user_actkey_time = " . TIMENOW . '
+			WHERE user_id = ' . $row['user_id'];
+        if (!DB()->sql_query($sql)) {
+            bb_die('Could not update new password information');
+        }
+
+        $emailer = new TorrentPier\Emailer;
+        $emailer->set_to($row['user_email'], $username);
+        $emailer->set_subject(__('EMAILER_SUBJECT')['USER_ACTIVATE_PASSWD']);
+        $emailer->set_template('user_activate_passwd', $row['user_lang']);
+        $emailer->assign_vars([
+            'USERNAME' => $username,
+            'PASSWORD' => $user_password,
+            'U_ACTIVATE' => make_url(ACTIVATE_URL . $user_id . '/' . $user_actkey . '/'),
+        ]);
+        $emailer->send();
+    }
+
+    bb_die(__('PASSWORD_UPDATED'), 200);
 } else {
     $email = $username = '';
 }

--- a/library/includes/ucp/twofactor.php
+++ b/library/includes/ucp/twofactor.php
@@ -20,7 +20,7 @@ $user_id = (int)userdata('user_id');
 
 // Allow disable even when feature is off, so users aren't trapped with stale 2FA
 if (!two_factor()->isFeatureEnabled() && !(request()->getString('action', '') === 'disable' && two_factor()->isEnabledForUser($user_id))) {
-    bb_die(__('TWO_FACTOR_FEATURE_DISABLED'));
+    bb_die(__('TWO_FACTOR_FEATURE_DISABLED'), 403);
 }
 
 $action = request()->getString('action', '');
@@ -33,7 +33,7 @@ switch ($action) {
         if (request()->isPost() && request()->post->has('verify_2fa')) {
             // Guard against dual-tab race condition
             if (two_factor()->isEnabledForUser($user_id)) {
-                bb_die(__('TWO_FACTOR_ALREADY_ENABLED'));
+                bb_die(__('TWO_FACTOR_ALREADY_ENABLED'), 409);
             }
 
             // POST: Verify the code and enable 2FA
@@ -41,7 +41,7 @@ switch ($action) {
             $code = (string)request()->post->get('totp_code', '');
 
             if (empty($setup_token) || empty($code)) {
-                bb_die(__('TWO_FACTOR_INVALID_CODE'));
+                bb_die(__('TWO_FACTOR_INVALID_CODE'), 400);
             }
 
             // Retrieve cached secret by setup token
@@ -49,7 +49,7 @@ switch ($action) {
             $cached = CACHE('bb_cache')->get($cache_key);
 
             if (!$cached || !isset($cached['secret'], $cached['user_id']) || $cached['user_id'] !== $user_id) {
-                bb_die(__('TWO_FACTOR_SETUP_EXPIRED'));
+                bb_die(__('TWO_FACTOR_SETUP_EXPIRED'), 410);
             }
 
             $secret = $cached['secret'];
@@ -59,10 +59,10 @@ switch ($action) {
                 $cached['attempts'] = ($cached['attempts'] ?? 0) + 1;
                 if ($cached['attempts'] >= 5) {
                     CACHE('bb_cache')->rm($cache_key);
-                    bb_die(__('TWO_FACTOR_SETUP_EXPIRED'));
+                    bb_die(__('TWO_FACTOR_SETUP_EXPIRED'), 410);
                 }
                 CACHE('bb_cache')->set($cache_key, $cached, 600);
-                bb_die(__('TWO_FACTOR_INVALID_CODE'));
+                bb_die(__('TWO_FACTOR_INVALID_CODE'), 400);
             }
 
             // Enable 2FA for this user
@@ -83,7 +83,7 @@ switch ($action) {
 
         // GET: Generate secret and show setup page
         if (two_factor()->isEnabledForUser($user_id)) {
-            bb_die(__('TWO_FACTOR_ALREADY_ENABLED'));
+            bb_die(__('TWO_FACTOR_ALREADY_ENABLED'), 409);
         }
 
         $secret = two_factor()->generateSecret();
@@ -112,14 +112,14 @@ switch ($action) {
         $token = request()->getString('token', '');
 
         if (empty($token)) {
-            bb_die(__('TWO_FACTOR_INVALID_TOKEN'));
+            bb_die(__('TWO_FACTOR_INVALID_TOKEN'), 400);
         }
 
         $cache_key = '2fa_recovery_' . $token;
         $cached = CACHE('bb_cache')->get($cache_key);
 
         if (!$cached || !isset($cached['codes'], $cached['user_id']) || $cached['user_id'] !== $user_id) {
-            bb_die(__('TWO_FACTOR_RECOVERY_EXPIRED'));
+            bb_die(__('TWO_FACTOR_RECOVERY_EXPIRED'), 410);
         }
 
         // Prepare download token (same token, separate cache entry for download)
@@ -146,30 +146,30 @@ switch ($action) {
          */
     case 'disable':
         if (!two_factor()->isEnabledForUser($user_id)) {
-            bb_die(__('TWO_FACTOR_NOT_ENABLED'));
+            bb_die(__('TWO_FACTOR_NOT_ENABLED'), 409);
         }
 
         if (request()->isPost() && request()->post->has('disable_2fa')) {
             $code = (string)request()->post->get('totp_code', '');
 
             if (empty($code)) {
-                bb_die(__('TWO_FACTOR_INVALID_CODE'));
+                bb_die(__('TWO_FACTOR_INVALID_CODE'), 400);
             }
 
             if (!two_factor()->checkRateLimit($user_id)) {
-                bb_die(__('TWO_FACTOR_TOO_MANY_ATTEMPTS'));
+                bb_die(__('TWO_FACTOR_TOO_MANY_ATTEMPTS'), 429);
             }
 
             if (!two_factor()->verifyUserCode($user_id, $code)) {
                 two_factor()->incrementAttempts($user_id);
-                bb_die(__('TWO_FACTOR_INVALID_CODE'));
+                bb_die(__('TWO_FACTOR_INVALID_CODE'), 400);
             }
 
             two_factor()->clearAttempts($user_id);
             two_factor()->disableForUser($user_id);
 
             meta_refresh(SETTINGS_URL, 5);
-            bb_die(__('TWO_FACTOR_DISABLED_SUCCESS'));
+            bb_die(__('TWO_FACTOR_DISABLED_SUCCESS'), 200);
         }
 
         // GET: Show disable confirmation form
@@ -184,23 +184,23 @@ switch ($action) {
          */
     case 'regenerate':
         if (!two_factor()->isEnabledForUser($user_id)) {
-            bb_die(__('TWO_FACTOR_NOT_ENABLED'));
+            bb_die(__('TWO_FACTOR_NOT_ENABLED'), 409);
         }
 
         if (request()->isPost() && request()->post->has('regenerate_codes')) {
             $code = (string)request()->post->get('totp_code', '');
 
             if (empty($code)) {
-                bb_die(__('TWO_FACTOR_INVALID_CODE'));
+                bb_die(__('TWO_FACTOR_INVALID_CODE'), 400);
             }
 
             if (!two_factor()->checkRateLimit($user_id)) {
-                bb_die(__('TWO_FACTOR_TOO_MANY_ATTEMPTS'));
+                bb_die(__('TWO_FACTOR_TOO_MANY_ATTEMPTS'), 429);
             }
 
             if (!two_factor()->verifyUserCode($user_id, $code)) {
                 two_factor()->incrementAttempts($user_id);
-                bb_die(__('TWO_FACTOR_INVALID_CODE'));
+                bb_die(__('TWO_FACTOR_INVALID_CODE'), 400);
             }
 
             two_factor()->clearAttempts($user_id);
@@ -233,14 +233,14 @@ switch ($action) {
         $token = request()->getString('token', '');
 
         if (empty($token)) {
-            bb_die(__('TWO_FACTOR_INVALID_TOKEN'));
+            bb_die(__('TWO_FACTOR_INVALID_TOKEN'), 400);
         }
 
         $cache_key = '2fa_download_' . $token;
         $cached = CACHE('bb_cache')->get($cache_key);
 
         if (!$cached || !isset($cached['codes'], $cached['user_id']) || $cached['user_id'] !== $user_id) {
-            bb_die(__('TWO_FACTOR_DOWNLOAD_EXPIRED'));
+            bb_die(__('TWO_FACTOR_DOWNLOAD_EXPIRED'), 410);
         }
 
         // Clean up after download
@@ -271,14 +271,14 @@ switch ($action) {
         $setup_token = request()->getString('setup_token', '');
 
         if (empty($setup_token)) {
-            bb_die(__('TWO_FACTOR_INVALID_TOKEN'));
+            bb_die(__('TWO_FACTOR_INVALID_TOKEN'), 400);
         }
 
         $cache_key = '2fa_setup_' . $setup_token;
         $cached = CACHE('bb_cache')->get($cache_key);
 
         if (!$cached || !isset($cached['secret'], $cached['user_id']) || $cached['user_id'] !== $user_id) {
-            bb_die(__('TWO_FACTOR_SETUP_EXPIRED'));
+            bb_die(__('TWO_FACTOR_SETUP_EXPIRED'), 410);
         }
 
         $qrImage = two_factor()->generateQrCode(

--- a/library/includes/ucp/viewprofile.php
+++ b/library/includes/ucp/viewprofile.php
@@ -17,10 +17,16 @@ if (IS_GUEST) {
     redirect(LOGIN_URL . '?redirect=' . request()->server->get('REQUEST_URI'));
 }
 
-$user_id = request()->query->getInt(POST_USERS_URL) ?: userdata('user_id');
+$user_id = request()->query->has(POST_USERS_URL)
+    ? request()->query->getInt(POST_USERS_URL)
+    : (int)userdata('user_id');
+
+if ($user_id <= 0) {
+    bb_die(__('NO_USER_ID_SPECIFIED'), 404);
+}
 
 if (!$profiledata = get_userdata($user_id)) {
-    bb_die(__('NO_USER_ID_SPECIFIED'));
+    bb_die(__('NO_USER_ID_SPECIFIED'), 404);
 }
 
 // Assert canonical URL for SEO-friendly routing

--- a/resources/views/default/login.twig
+++ b/resources/views/default/login.twig
@@ -20,12 +20,12 @@
                     <table class="borderless bCenter">
                         <tr>
                             <td width="35%" class="tRight">{{ __('USERNAME') }}:</td>
-                            <td><input type="text" class="post" name="login_username" size="25" maxlength="40" value="{{ LOGIN_USERNAME }}" tabindex="101"{% if ADMIN_LOGIN %} readonly style="color: gray"{% endif %} />
+                            <td><input type="text" class="post" name="login_username" size="25" maxlength="40" autocomplete="username" value="{{ LOGIN_USERNAME }}" tabindex="101"{% if ADMIN_LOGIN %} readonly style="color: gray"{% endif %} />
                             </td>
                         </tr>
                         <tr>
                             <td class="tRight">{{ __('PASSWORD') }}:</td>
-                            <td><input type="password" class="post show_pass_input" name="login_password" value="{{ LOGIN_PASSWORD }}" tabindex="102" size="25" maxlength="32"/>&nbsp;<label><input type="checkbox" class="password_show_checkbox">&nbsp;{{ __('PASSWORD_SHOW_BTN') }}</label></td>
+                            <td><input type="password" class="post show_pass_input" name="login_password" value="{{ LOGIN_PASSWORD }}" tabindex="102" size="25" maxlength="128" autocomplete="current-password"/>&nbsp;<label><input type="checkbox" class="password_show_checkbox">&nbsp;{{ __('PASSWORD_SHOW_BTN') }}</label></td>
                         </tr>
                         {% if CAPTCHA_HTML %}
                         <tr>

--- a/resources/views/default/usercp_register.twig
+++ b/resources/views/default/usercp_register.twig
@@ -71,29 +71,29 @@
         </tr>
         <tr>
             <td class="prof-title">{{ __('USERNAME') }}: *</td>
-            <td>{% if CAN_EDIT_USERNAME %}<input id="username" onBlur="ajax.exec({ action: 'user_register', mode: 'check_name', username: $('#username').val()}); return false;" type="text" name="username" size="35" maxlength="25" value="{{ USERNAME }}"/>{% else %}<b>{{ USERNAME }}</b>{% endif %}&nbsp;<span id="check_name"></span></td>
+            <td>{% if CAN_EDIT_USERNAME %}<input id="username" onBlur="ajax.exec({ action: 'user_register', mode: 'check_name', username: $('#username').val()}); return false;" type="text" name="username" size="35" maxlength="30" autocomplete="username" value="{{ USERNAME }}"/>{% else %}<b>{{ USERNAME }}</b>{% endif %}&nbsp;<span id="check_name"></span></td>
         </tr>
         <tr>
             <td class="prof-title">{{ __('EMAIL') }}: * {% if EDIT_PROFILE %}{% elseif config('auth.registration.email_activation') %}<br/><h6>{{ __('EMAIL_EXPLAIN') }}</h6>{% endif %}</td>
-            <td><input id="email" onBlur="ajax.exec({ action: 'user_register', mode: 'check_email', email: $('#email').val()}); return false;" type="text" name="user_email" size="35" maxlength="40" value="{{ USER_EMAIL }}"{% if EDIT_PROFILE and not ADM_EDIT and not IS_ADMIN %}{% if not config('mail.enabled') or config('mail.email_change_disabled') %} readonly style="color: gray;"{% endif %}{% endif %} />&nbsp;<span id="check_email"></span></td>
+            <td><input id="email" onBlur="ajax.exec({ action: 'user_register', mode: 'check_email', email: $('#email').val()}); return false;" type="email" name="user_email" size="35" maxlength="230" autocomplete="email" value="{{ USER_EMAIL }}"{% if EDIT_PROFILE and not ADM_EDIT and not IS_ADMIN %}{% if not config('mail.enabled') or config('mail.email_change_disabled') %} readonly style="color: gray;"{% endif %}{% endif %} />&nbsp;<span id="check_email"></span></td>
         </tr>
         {% if EDIT_PROFILE and not ADM_EDIT %}
         <tr>
             <td class="prof-title">{{ __('CURRENT_PASSWORD') }}: * <br/><h6>{{ __('CONFIRM_PASSWORD_EXPLAIN') }}</h6></td>
-            <td><input class="show_pass_input" type="password" name="cur_pass" size="35" maxlength="32" value=""/>&nbsp;<label><input type="checkbox" class="password_show_checkbox">&nbsp;{{ __('PASSWORD_SHOW_BTN') }}</label></td>
+            <td><input class="show_pass_input" type="password" name="cur_pass" size="35" maxlength="128" autocomplete="current-password" value=""/>&nbsp;<label><input type="checkbox" class="password_show_checkbox">&nbsp;{{ __('PASSWORD_SHOW_BTN') }}</label></td>
         </tr>
         {% endif %}
         <tr>
             <td class="prof-title">{% if EDIT_PROFILE %}{{ __('NEW_PASSWORD') }}: * <br/><h6>{{ __('PASSWORD_IF_CHANGED') }}</h6>{% else %}{{ __('PASSWORD') }}: *{% endif %}</td>
             <td>
-                <input id="pass" type="{% if SHOW_PASS %}text{% else %}password{% endif %}" name="new_pass" size="35" maxlength="32" value=""/>&nbsp;<span id="autocomplete" data-password-length="{{ constant('PASSWORD_MIN_LENGTH') }}" title="{{ __('AUTOCOMPLETE') }}">&#9668;</span>&nbsp;<i class="med">{{ PASSWORD_LONG }}</i>
+                <input id="pass" type="{% if SHOW_PASS %}text{% else %}password{% endif %}" name="new_pass" size="35" maxlength="128" autocomplete="new-password" value=""/>&nbsp;<span id="autocomplete" data-password-length="{{ constant('PASSWORD_MIN_LENGTH') }}" title="{{ __('AUTOCOMPLETE') }}">&#9668;</span>&nbsp;<i class="med">{{ PASSWORD_LONG }}</i>
             </td>
         </tr>
         <tr>
             <td class="prof-title">{{ __('CONFIRM_PASSWORD') }}: * {% if EDIT_PROFILE %}<br/>
                 <h6>{{ __('PASSWORD_CONFIRM_IF_CHANGED') }}</h6>{% endif %}</td>
             <td>
-                <input id="pass_confirm" onBlur="ajax.exec({ action: 'user_register', mode: 'check_pass', pass: $('#pass').val(), pass_confirm: $('#pass_confirm').val() }); return false;" type="{% if SHOW_PASS %}text{% else %}password{% endif %}" name="cfm_pass" size="35" maxlength="32" value=""/>&nbsp;<span id="check_pass"></span>
+                <input id="pass_confirm" onBlur="ajax.exec({ action: 'user_register', mode: 'check_pass', pass: $('#pass').val(), pass_confirm: $('#pass_confirm').val() }); return false;" type="{% if SHOW_PASS %}text{% else %}password{% endif %}" name="cfm_pass" size="35" maxlength="128" autocomplete="new-password" value=""/>&nbsp;<span id="check_pass"></span>
             </td>
         </tr>
         {% if config('auth.invites.enabled') and not EDIT_PROFILE %}

--- a/resources/views/default/viewtopic.twig
+++ b/resources/views/default/viewtopic.twig
@@ -269,7 +269,12 @@ function build_poll_add_form (src_el)
 		<td class="small bold nowrap" style="padding: 0 0 0 4px;">
 			{% if IN_MODERATION %}{{ __('MODERATE_TOPIC') }}{% else %}<a href="{{ PAGE_URL }}{{ PAGE_URL_SEP }}mod=1&amp;start={{ PAGE_START }}" class="small bold">{{ __('MODERATE_TOPIC') }}</a>{% endif %}
 			&nbsp;<span style="color:#CDCDCD;">|</span>&nbsp;
-			<a class="small bold" href="{{ PIN_HREF }}">{{ PIN_TITLE }}</a>
+			<form id="pin-form" action="{{ constant('FORUM_PATH') }}modcp" method="post" style="display:inline">
+				{{ csrf_field() }}
+				<input type="hidden" name="{{ constant('POST_TOPIC_URL') }}" value="{{ V.TOPIC_ID }}">
+				<input type="hidden" name="mode" value="{{ PINNED_FIRST_POST ? 'post_unpin' : 'post_pin' }}">
+				<a class="small bold" href="#" onclick="document.getElementById('pin-form').submit(); return false;">{{ PIN_TITLE }}</a>
+			</form>
             &nbsp;<span style="color:#CDCDCD;">|</span>&nbsp;
             <a class="small bold" href="#" onclick="$('#main_content').printThis(); return false;">{{ __('PRINT_PAGE') }}</a>
 		</td>

--- a/src/Captcha/TextCaptcha.php
+++ b/src/Captcha/TextCaptcha.php
@@ -31,6 +31,14 @@ class TextCaptcha implements CaptchaInterface
     public function __construct(array $settings)
     {
         if (session_status() === PHP_SESSION_NONE) {
+            session_set_cookie_params([
+                'lifetime' => 0,
+                'path' => '/',
+                'domain' => '',
+                'secure' => !empty($_SERVER['HTTPS']),
+                'httponly' => true,
+                'samesite' => 'Lax',
+            ]);
             session_start();
         }
 

--- a/src/Feed/Provider/TopicVisibilityFilterTrait.php
+++ b/src/Feed/Provider/TopicVisibilityFilterTrait.php
@@ -31,7 +31,7 @@ trait TopicVisibilityFilterTrait
         return array_filter($topics, function ($topic) use ($notForumsId) {
             $forumId = isset($topic['forum_id']) ? (int)$topic['forum_id'] : 0;
 
-            return !\in_array($forumId, $notForumsId);
+            return !\in_array($forumId, $notForumsId, true);
         });
     }
 }

--- a/src/Feed/Provider/TopicVisibilityFilterTrait.php
+++ b/src/Feed/Provider/TopicVisibilityFilterTrait.php
@@ -18,33 +18,20 @@ namespace TorrentPier\Feed\Provider;
 trait TopicVisibilityFilterTrait
 {
     /**
-     * Filter topics from forbidden forums (for guests)
+     * Filter topics from forums the current viewer cannot see
      */
     private function filterForbiddenTopics(array $topics): array
     {
-        // Get forbidden forums for guests
-        $forums = forum_tree();
+        $notForumsId = user()->get_excluded_forums(AUTH_VIEW, 'array');
 
-        // Get guest_view string, default to empty
-        $guestView = $forums['not_auth_forums']['guest_view'] ?? '';
-
-        // Explode and cast to an int array (empty string produces an empty array)
-        $notForumsId = $guestView !== ''
-            ? array_map('intval', explode(',', $guestView))
-            : [];
-
-        // If no forbidden forums, return all topics
         if (empty($notForumsId)) {
             return $topics;
         }
 
-        // Filter out topics from forbidden forums
         return array_filter($topics, function ($topic) use ($notForumsId) {
-            // Get forum_id as int, default to 0 if missing
             $forumId = isset($topic['forum_id']) ? (int)$topic['forum_id'] : 0;
 
-            // Keep a topic if its forum is NOT in a forbidden list (strict comparison)
-            return !\in_array($forumId, $notForumsId, true);
+            return !\in_array($forumId, $notForumsId);
         });
     }
 }

--- a/src/Legacy/BBCode.php
+++ b/src/Legacy/BBCode.php
@@ -230,7 +230,7 @@ class BBCode
         $text = preg_replace_callback('#(\s*)\[code\](.+?)\[/code\](\s*)#s', [&$this, 'code_callback'], $text);
 
         // Escape tags inside titles in [quote="tilte"]
-        $text = preg_replace_callback('#(\[(quote|spoiler)=")(.+?)("\])#', [&$this, 'escape_titles_callback'], $text);
+        $text = preg_replace_callback('#(\[(quote|spoiler|acronym)=")(.+?)("\])#', [&$this, 'escape_titles_callback'], $text);
 
         // [url]
         $url_exp = '[\w\#!$%&~/.\-;:=,?@\p{Cyrillic}()\[\]+]+?';

--- a/src/Legacy/Post.php
+++ b/src/Legacy/Post.php
@@ -51,6 +51,10 @@ class Post
         // Check subject
         if (!empty($subject)) {
             $subject = str_replace('&amp;', '&', $subject);
+            if (mb_strlen($subject, 'UTF-8') > 250) {
+                $too_long = __('SUBJECT_TOO_LONG') !== 'SUBJECT_TOO_LONG' ? __('SUBJECT_TOO_LONG') : 'Subject must be 250 characters or fewer.';
+                $error_msg .= (!empty($error_msg)) ? '<br />' . $too_long : $too_long;
+            }
         } elseif ($mode == 'newtopic' || ($mode == 'editpost' && $post_data['first_post'])) {
             $error_msg .= (!empty($error_msg)) ? '<br />' . __('EMPTY_SUBJECT') : __('EMPTY_SUBJECT');
         }

--- a/src/Legacy/Post.php
+++ b/src/Legacy/Post.php
@@ -51,10 +51,7 @@ class Post
         // Check subject
         if (!empty($subject)) {
             $subject = str_replace('&amp;', '&', $subject);
-            if (mb_strlen($subject, 'UTF-8') > 250) {
-                $too_long = 'Subject must be 250 characters or fewer.';
-                $error_msg .= (!empty($error_msg)) ? '<br />' . $too_long : $too_long;
-            }
+            $subject = mb_substr($subject, 0, 250, 'UTF-8');
         } elseif ($mode == 'newtopic' || ($mode == 'editpost' && $post_data['first_post'])) {
             $error_msg .= (!empty($error_msg)) ? '<br />' . __('EMPTY_SUBJECT') : __('EMPTY_SUBJECT');
         }

--- a/src/Legacy/Post.php
+++ b/src/Legacy/Post.php
@@ -52,7 +52,7 @@ class Post
         if (!empty($subject)) {
             $subject = str_replace('&amp;', '&', $subject);
             if (mb_strlen($subject, 'UTF-8') > 250) {
-                $too_long = __('SUBJECT_TOO_LONG') !== 'SUBJECT_TOO_LONG' ? __('SUBJECT_TOO_LONG') : 'Subject must be 250 characters or fewer.';
+                $too_long = 'Subject must be 250 characters or fewer.';
                 $error_msg .= (!empty($error_msg)) ? '<br />' . $too_long : $too_long;
             }
         } elseif ($mode == 'newtopic' || ($mode == 'editpost' && $post_data['first_post'])) {

--- a/src/Whoops/WhoopsManager.php
+++ b/src/Whoops/WhoopsManager.php
@@ -108,20 +108,25 @@ class WhoopsManager
     private function registerPlaceholderHandler(): void
     {
         $this->whoops->pushHandler(function ($e, $inspector, $run) {
-            // League\Route\Http\Exception (NotFound, MethodNotAllowed, ...) carries
-            // its own status code; render the engine's themed error page via bb_die()
-            // so the user sees a real header/footer instead of a bare placeholder line.
-            if ($e instanceof \League\Route\Http\Exception && \function_exists('bb_die')) {
-                $status = $e->getStatusCode();
-                // bb_die() runs the lang lookup internally, so pass the key
-                $message = $status === 404 ? 'PAGE_NOT_FOUND' : config()->get('logging.whoops.error_message');
-
-                try {
-                    bb_die($message, $status); // exits; templated page with proper status
-                } catch (Throwable) {
-                    // Fall through to bare placeholder if engine isn't bootstrapped enough
+            // Render the engine's themed error page via bb_die() so the user
+            // sees a real header/footer instead of a bare placeholder line.
+            $dispatch = function (string $message, int $status) use ($run): void {
+                if (\function_exists('bb_die')) {
+                    try {
+                        bb_die($message, $status); // exits on success
+                    } catch (Throwable) {
+                        // Engine not bootstrapped enough; fall through to placeholder.
+                    }
                 }
                 $run->sendHttpCode($status);
+            };
+
+            if ($e instanceof \League\Route\Http\Exception) {
+                $status = $e->getStatusCode();
+                $dispatch($status === 404 ? 'PAGE_NOT_FOUND' : config()->get('logging.whoops.error_message'), $status);
+            } elseif ($e instanceof \Symfony\Component\HttpFoundation\Exception\BadRequestException) {
+                // Strict InputBag throws on non-scalar/non-numeric — surface as 400, not 500.
+                $dispatch('Bad request', 400);
             }
 
             echo config()->get('logging.whoops.error_message');

--- a/tests/Integration/CsrfMiddlewareTest.php
+++ b/tests/Integration/CsrfMiddlewareTest.php
@@ -34,6 +34,21 @@ beforeEach(function () {
         $this->markTestSkipped("TorrentPier instance not reachable at {$this->base}");
     }
 
+    // Clear any leftover invalid-login lockouts so the captcha doesn't flap
+    // the admin re-login step below.
+    $lockoutDir = __DIR__ . '/../../storage/framework/cache/filecache/bb_login_err';
+    if (is_dir($lockoutDir)) {
+        $rii = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($lockoutDir, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($rii as $entry) {
+            if ($entry->isFile()) {
+                @unlink($entry->getPathname());
+            }
+        }
+    }
+
     $this->cookieJar = [];
 });
 

--- a/tests/Unit/BBCodeAcronymTest.php
+++ b/tests/Unit/BBCodeAcronymTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * Mock config() for BBCode tests (same shim as BBCodeUrlTest).
+ */
+
+namespace TorrentPier\Legacy {
+    if (!\function_exists('TorrentPier\Legacy\config')) {
+        function config()
+        {
+            return new class {
+                public function get(string $key)
+                {
+                    return match ($key) {
+                        'forum.nofollow.allowed_url' => [],
+                        'forum.nofollow.disabled' => true,
+                        'forum.tidy_post' => false,
+                        default => null,
+                    };
+                }
+            };
+        }
+    }
+}
+
+namespace {
+    use TorrentPier\Legacy\BBCode;
+
+    /**
+     * Regression tests for stored XSS via [acronym="..."] title attribute.
+     */
+    describe('BBCode [acronym=...] title escaping', function () {
+        function parseAcronym(string $text): string
+        {
+            $bbcode = new BBCode;
+            $reflection = new ReflectionMethod($bbcode, 'parse');
+
+            return $reflection->invoke($bbcode, $text);
+        }
+
+        function acronymAttributes(string $rendered): array
+        {
+            $doc = new DOMDocument;
+            // wrap to make the fragment a valid HTML doc
+            $ok = @$doc->loadHTML('<!doctype html><html><body>' . $rendered . '</body></html>', LIBXML_NOERROR | LIBXML_NOWARNING);
+            expect($ok)->toBeTrue();
+
+            $span = $doc->getElementsByTagName('span')->item(0);
+            expect($span)->not->toBeNull();
+
+            $attrs = [];
+            foreach ($span->attributes as $a) {
+                $attrs[$a->nodeName] = $a->nodeValue;
+            }
+
+            return $attrs;
+        }
+
+        it('parses benign acronym correctly', function () {
+            $result = parseAcronym('[acronym="HTML"]Hyper Text Markup Language[/acronym]');
+            $attrs = acronymAttributes($result);
+
+            expect($attrs)->toHaveKey('class', 'post-acronym')
+                ->and($attrs)->toHaveKey('title', 'HTML')
+                ->and(array_keys($attrs))->toEqualCanonicalizing(['class', 'title']);
+        });
+
+        it('rejects onmouseover attribute injection', function () {
+            $result = parseAcronym('[acronym="x" onmouseover="alert(1)"]hover[/acronym]');
+            $attrs = acronymAttributes($result);
+
+            expect(array_keys($attrs))->toEqualCanonicalizing(['class', 'title'])
+                ->and($attrs)->not->toHaveKey('onmouseover');
+        });
+
+        it('rejects autofocus + onfocus attribute injection', function () {
+            $result = parseAcronym('[acronym="" autofocus onfocus="alert(1)" "]y[/acronym]');
+            $attrs = acronymAttributes($result);
+
+            expect(array_keys($attrs))->toEqualCanonicalizing(['class', 'title'])
+                ->and($attrs)->not->toHaveKey('autofocus')
+                ->and($attrs)->not->toHaveKey('onfocus');
+        });
+
+        it('rejects apostrophe-based injection', function () {
+            $result = parseAcronym("[acronym=\"' onmouseover='alert(1)\"]y[/acronym]");
+            $attrs = acronymAttributes($result);
+
+            expect(array_keys($attrs))->toEqualCanonicalizing(['class', 'title']);
+        });
+
+        it('rejects inline style injection', function () {
+            $result = parseAcronym('[acronym="x" style="position:fixed;inset:0;background:red" "]click[/acronym]');
+            $attrs = acronymAttributes($result);
+
+            expect(array_keys($attrs))->toEqualCanonicalizing(['class', 'title']);
+        });
+    });
+}


### PR DESCRIPTION
## Summary

End-to-end audit of the user-facing pages — `/tracker`, `/search`, `/members`, `/settings`, `/profile/*`, `/threads/*`, `/forums/*`, `/posting`, `/privmsg`, `/feed/*`, `/modcp`, and the auth / register / recovery flow. The findings break down into 7 critical, 4 systemic and 11 targeted fixes plus test-infra hardening.

The audit was run via Playwright + curl + code/DB cross-reference. Local validation: **1599 / 1599 Pest tests pass**.

## Critical

| # | What | Fix |
|---|---|---|
| **CRIT-1** | Authenticated SQL injection via `/tracker?status[]=` — bcrypt hash of `admin` leaked through MySQL error oracle (confirmed in `storage/logs/database_errors.log`) | `app/Http/Controllers/tracker.php` — cast every element to int (`array_map('intval', ...)`) before splicing into `IN(...)` |
| **CRIT-2** | Stored XSS via `[acronym="x" onmouseover=\"alert(1)\"]…[/acronym]` — title-attribute injection executes JS on hover | `src/Legacy/BBCode.php:233` — extend `escape_titles_callback` regex from `(quote\|spoiler)` to `(quote\|spoiler\|acronym)`. Regression coverage in `tests/Unit/BBCodeAcronymTest.php` (5 DOM-validated cases) |
| **CRIT-3** | `ChangeTorStatusController::handleStatusReply` registered as user-tier but sent PM to the last moderator who changed status — PM-spam vector | `app/Http/Controllers/Api/Ajax/ChangeTorStatusController.php` — require IS_AM **or** the torrent's own `poster_id`; bail out on empty `checked_user_id` |
| **CRIT-4** | RSS feed (`/feed/f/{id}/`) RBAC bypass: non-numeric `id` silently coerced to 0 → dumps global feed; `TopicVisibilityFilterTrait` only filtered guest-restricted forums, leaking private forums to authenticated users without read rights | `app/Http/Controllers/feed.php` — strict `ctype_digit` parse; `src/Feed/Provider/TopicVisibilityFilterTrait.php` — filter by `user()->get_excluded_forums(AUTH_VIEW)` |
| **CRIT-5** | User-enumeration / status-probe oracles: `/password-recovery` returned four distinct messages (`NO_EMAIL_MATCH`, `NO_SEND_ACCOUNT_INACTIVE`, `NO_SEND_ACCOUNT`, `PASSWORD_UPDATED`); `/activate/{u}/{key}/` distinguished nonexistent vs. already-active user | `library/includes/ucp/sendpasswd.php` + `library/includes/ucp/activate.php` — collapse all outcomes to one neutral reply; keep the recovery-mail logic gated on internal `$eligible` |
| **CRIT-6** | Reflected XSS via `/api/ajax/user-register?mode=check_country` — `render_flag()` returned the raw `$code` on its fallback branches, sink was `$('#check_country').html(data.html)` | `library/includes/functions.php` — `htmlCHR()` every return path of `render_flag()` |

## Systemic

* **`clean_text_match()`** — strip MySQL BOOLEAN MODE meta chars (`< > ( ) ~ @` + unbalanced `\"`) when `forum.allow_search_in_bool_mode` is on. Closes the chain of HTTP 500s observed on `/tracker?nm=…`, `/search?nm=…`, `/forums/x?nm=…`, `/threads/y?nm=…` for payloads like `<x>`, `@test`, `' OR 1=1`.
* **Explicit `bb_die()` status codes** across the user-facing controllers (404 / 400 / 403 / 410 / 429 / 409). Picks up where the recent admin pass left off (`b82c9c60`, `dac7da10`). Touches: `viewtopic`, `viewforum`, `posting`, `dl`, `privmsg`, `viewprofile`, `twofactor`, `sendpasswd`, `activate`, `modcp`.
* **`Whoops\WhoopsManager`** — convert `Symfony\…\BadRequestException` (thrown by `query->getInt('start' | 'pid' | …)` on non-numeric input) into HTTP 400 via the engine's themed page, instead of letting it bubble up as 500. Common dispatch helper shared with the existing `League\Route\Http\Exception` branch.
* **modcp CSRF gap** — `lock`, `unlock`, `post_pin`, `post_unpin`, `set_download`, `unset_download` previously ran `UPDATE` on `GET` (CSRF middleware only protects POST/PUT/PATCH/DELETE). Mutating modes are now POST-only; 405 otherwise.

## Targeted fixes

* `ViewPostController` — reject empty `post_id`+`topic_id` instead of producing `WHERE post_id =` (SQL syntax 500); return correct `topic_id` from DB instead of echoing the (possibly null) raw input.
* `ModActionController::handleEditTopicTitle` — validate `topic_id` **before** calling `get_topic_title()`; single combined `SELECT topic_title, forum_id`.
* `get_forum_display_sort_option()` — off-by-one fix (`?sort=3`, `?order=2` raised 500). Switched to `!isset($listrow['fields'][...])` as defence-in-depth.
* `memberlist.php` — force DESC for `mode=topten`; "top ten" was showing the bottom ten because the default order was ASC.
* `search.php` — require at least one user-supplied filter (`text_match_sql`, `poster_id`, `forum`, `topic`, `time`, `dl`, `new_posts`, `new_topics`); reject wildcard-only username-popup queries (`*`, `%`, lone `_`).
* `viewprofile.php` — reject `?u=0` / non-positive id with 404 instead of silently rendering the viewer's own profile.
* `ChangeUserRankController` — reject non-numeric `rank_id` (was silently coerced to 0 = strip rank); `htmlCHR()` rank title/style.
* `Post::prepare_post` — server-side max-length check for the subject (250 chars).
* `login.twig` / `usercp_register.twig` — align password / email / username `maxlength` with the actual server-side limits (`PASSWORD_MAX_LENGTH=128`, `USEREMAIL_MAX_LENGTH=230`, `USERNAME_MAX_LENGTH=30`) and add `autocomplete` attributes (`username`, `email`, `current-password`, `new-password`) so password managers can do their job.
* `Captcha\TextCaptcha` — set `HttpOnly` / `SameSite=Lax` / `Secure` (when HTTPS) on the PHPSESSID cookie before `session_start()`.

## Test infra

* `tests/Integration/CsrfMiddlewareTest` — clear the `bb_login_err` filecache lockout in `beforeEach` so accumulated invalid-login probes from earlier runs don't flap the admin re-login step. Made the test deterministic without changing any production code.

## Test plan

- [x] `./vendor/bin/pest` — 1599 / 1599 passing
- [x] `tests/Unit/BBCodeAcronymTest.php` — 5 / 5 (DOM-validated XSS regression)
- [x] `tests/Integration/CsrfMiddlewareTest.php` — 6 / 6 (incl. the previously flaky admin-login case)
- [x] Manual curl repro of CRIT-1, CRIT-4, CRIT-6 against `tp.test` — all return safe responses after the fix
- [x] Manual hover-probe of the BBCode preview for CRIT-2 — no JS execution after fix

## Out of scope / follow-up

* `getInt`-style helpers everywhere in the legacy controllers — many call `request()->query->getInt()` directly. The Whoops 400 wrapper catches the runtime fallout, but a sweep replacing the calls with `request()->getInt()` (which already has try/catch in `src/Http/Request.php`) is a separate cleanup.
* Language-file strings were intentionally **not** edited (PASSWORD_UPDATED text is unchanged); the enumeration fix relies on the controller always emitting the same key regardless of internal outcome.
* `/dl/{id}/files/` listing for guests was reviewed and confirmed by-design — the link is intentionally advertised in `viewtopic_attach_guest.twig`. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)